### PR TITLE
Add normalize_columns to public API

### DIFF
--- a/ogum/__init__.py
+++ b/ogum/__init__.py
@@ -13,6 +13,7 @@ from .core import (
     boltzmann_sigmoid,
     generalized_logistic_stable,
 )
+from .utils import normalize_columns
 
 __all__ = [
     "R",
@@ -26,4 +27,5 @@ __all__ = [
     "gerar_link_download",
     "boltzmann_sigmoid",
     "generalized_logistic_stable",
+    "normalize_columns",
 ]

--- a/ogum/core.py
+++ b/ogum/core.py
@@ -9,6 +9,8 @@ from io import BytesIO
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from .utils import normalize_columns
+
 import numpy as np
 import pandas as pd
 try:
@@ -136,4 +138,5 @@ __all__ = [
     "gerar_link_download",
     "boltzmann_sigmoid",
     "generalized_logistic_stable",
+    "normalize_columns",
 ]

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,4 +1,8 @@
 import importlib
- main
-def test_imports(m):
-    assert importlib.import_module(m)
+import pytest
+
+
+@pytest.mark.parametrize("module", ["ogum", "ogum.core", "ogum.utils"])
+def test_imports(module):
+    assert importlib.import_module(module)
+


### PR DESCRIPTION
## Summary
- expose `normalize_columns` via `ogum.core`
- re-export utilities from package root
- fix broken import test to properly check module availability

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dfe8a6af8832790b1de983d5e39bc