### PR TITLE
Refactor modules to rely on utils helpers

### DIFF
--- a/ogum/ogum80.py
+++ b/ogum/ogum80.py
@@ -43,6 +43,18 @@ from scipy.stats import linregress
 # Exige scipy>=1.6 para a localização de cumtrapz em .integrate
 try:
     from scipy.integrate import cumtrapz
+except ImportError:  # pragma: no cover - optional dependency
+    def cumtrapz(y, x=None, initial=0):
+        y = np.asarray(y)
+        if x is None:
+            x = np.arange(len(y))
+        else:
+            x = np.asarray(x)
+        res = [initial]
+        for i in range(1, len(y)):
+            trap = (y[i-1] + y[i]) * (x[i] - x[i-1]) / 2.0
+            res.append(res[-1] + trap)
+        return np.array(res)
 
 # ==============================================================================
 # Constantes Globais
@@ -841,15 +853,13 @@ import matplotlib.pyplot as plt
 from typing import List
 
 # Importações do Módulo 1
-from modulo1_interface import (
+from ogum.utils import (
     SinteringDataRecord,
-    EaSelectionWidget,
     exibir_mensagem,
     exibir_erro,
     gerar_link_download,
-    R,
-    cumtrapz
 )
+
 
 class ModuloLogTheta:
     """
@@ -1000,7 +1010,7 @@ from scipy.interpolate import interp1d
 from collections import defaultdict
 from typing import List
 
-from modulo1_interface import SinteringDataRecord, exibir_mensagem, exibir_erro
+from ogum.utils import SinteringDataRecord, exibir_mensagem, exibir_erro
 
 class Modulo5_1Alinhamento:
     """
@@ -1112,12 +1122,12 @@ import pandas as pd
 import matplotlib.pyplot as plt
 from typing import List
 
-from modulo1_interface import (
+from ogum.utils import (
     SinteringDataRecord,
     exibir_mensagem,
     exibir_erro,
     gerar_link_download,
-    DataHistory
+    DataHistory,
 )
 
 class Modulo5_2BlaineParameters:
@@ -1910,11 +1920,11 @@ from typing import List
 from collections import defaultdict
 
 # Importações necessárias do Módulo 1
-from modulo1_interface import (
+from ogum.utils import (
     SinteringDataRecord,
     exibir_mensagem,
     exibir_erro,
-    boltzmann_sigmoid
+    boltzmann_sigmoid,
 )
 
 class Modulo5_4_2Ref:
@@ -2072,7 +2082,7 @@ from scipy.stats import linregress
 import matplotlib.pyplot as plt
 from typing import List
 
-from modulo1_interface import SinteringDataRecord, exibir_mensagem, exibir_erro
+from ogum.utils import SinteringDataRecord, exibir_mensagem, exibir_erro
 
 class Modulo5_4_3BlaineLinear:
     """
@@ -2502,53 +2512,14 @@ import pandas as pd
 from scipy.signal import savgol_filter
 from scipy.interpolate import interp1d
 
-# Importações de utilitários do Módulo 1
-from modulo1_interface import exibir_mensagem, exibir_erro, gerar_link_download
-
-
-def _calculate_derivatives_robust(df: pd.DataFrame, time_col: str, temp_col: str, dens_col: str):
-    """
-    Calcula derivadas de T e p em relação ao tempo e à temperatura,
-    aplicando filtro Savitzky-Golay para suavização prévia.
-    Retorna interpoladores de T(dens), dT/dt(dens) e dp/dT(dens).
-    """
-    # Ordena e copia
-    df_sorted = df.sort_values(time_col).reset_index(drop=True)
-    n_pts = len(df_sorted)
-    if n_pts < 5:
-        raise ValueError("Dados insuficientes (<5 pontos) para cálculo robusto.")
-
-    # Determina janela ímpar para filtro
-    max_win = 11
-    win = min(max_win, n_pts if n_pts % 2 == 1 else n_pts - 1)
-    window_length = win if win >= 5 else (5 if n_pts >= 5 else n_pts)
-    if window_length >= 5:
-        y_vals = savgol_filter(df_sorted[dens_col].values, window_length, 2)
-        T_vals = savgol_filter(df_sorted[temp_col].values + 273.15, window_length, 2)
-    else:
-        y_vals = df_sorted[dens_col].values
-        T_vals = df_sorted[temp_col].values + 273.15
-
-    # Derivadas
-    dTdt = np.gradient(T_vals, df_sorted[time_col].values)
-    dpdT = np.gradient(y_vals, T_vals)
-
-    # Prepara para interpolação: garante densidade estritamente crescente
-    interp_df = pd.DataFrame({
-        'dens': y_vals,
-        'T': T_vals,
-        'dTdt': dTdt,
-        'dpdT': dpdT
-    }).sort_values('dens').drop_duplicates('dens')
-
-    if len(interp_df) < 2:
-        raise ValueError("Dados insuficientes após filtragem para interpolação.")
-
-    f_T = interp1d(interp_df['dens'], interp_df['T'], kind='linear', bounds_error=False, fill_value='extrapolate')
-    f_dTdt = interp1d(interp_df['dens'], interp_df['dTdt'], kind='linear', bounds_error=False, fill_value='extrapolate')
-    f_dpdT = interp1d(interp_df['dens'], interp_df['dpdT'], kind='linear', bounds_error=False, fill_value='extrapolate')
-
-    return f_T, f_dTdt, f_dpdT
+# Importações de utilidades
+from ogum.utils import (
+    exibir_mensagem,
+    exibir_erro,
+    gerar_link_download,
+    calculate_derivatives_robust,
+    orlandini_araujo_filter,
+)
 
 
 class Modulo6_0_Arrhenius:
@@ -2617,7 +2588,7 @@ class Modulo6_0_Arrhenius:
             )
 
             try:
-                f_T, f_dTdt, f_dpdT = _calculate_derivatives_robust(
+                f_T, f_dTdt, f_dpdT = calculate_derivatives_robust(
                     df_clean, time_col, temp_col, dens_col
                 )
             except Exception as e:
@@ -2687,7 +2658,7 @@ from scipy.stats import linregress
 from collections import defaultdict
 
 # Utilitários do Módulo 1
-from modulo1_interface import exibir_mensagem, exibir_erro, gerar_link_download, R
+from ogum.utils import exibir_mensagem, exibir_erro, gerar_link_download
 
 class Modulo6_1ArrheniusDisplay:
     """

--- a/ogum/utils.py
+++ b/ogum/utils.py
@@ -2,7 +2,24 @@
 from __future__ import annotations
 
 from typing import Dict, Iterable
+
+import numpy as np
 import pandas as pd
+from scipy.interpolate import interp1d
+from scipy.signal import savgol_filter
+
+from .core import (
+    DataHistory,
+    SinteringDataRecord,
+    add_suffix_once,
+    criar_titulo,
+    exibir_mensagem,
+    exibir_erro,
+    criar_caixa_colapsavel,
+    gerar_link_download,
+    boltzmann_sigmoid,
+    generalized_logistic_stable,
+)
 
 
 def normalize_columns(df: pd.DataFrame, mapping: Dict[str, Iterable[str]]) -> pd.DataFrame:
@@ -25,4 +42,73 @@ def normalize_columns(df: pd.DataFrame, mapping: Dict[str, Iterable[str]]) -> pd
                 break
     return df.rename(columns=rename_dict)
 
-__all__ = ["normalize_columns"]
+
+def calculate_derivatives_robust(
+    df: pd.DataFrame, time_col: str, temp_col: str, dens_col: str
+) -> tuple[interp1d, interp1d, interp1d]:
+    """Return interpolators for T, dT/dt and dp/dT as functions of density."""
+    df_sorted = df.sort_values(time_col).reset_index(drop=True)
+    n_pts = len(df_sorted)
+    if n_pts < 5:
+        raise ValueError("Dados insuficientes (<5 pontos) para cálculo robusto.")
+
+    max_win = 11
+    win = min(max_win, n_pts if n_pts % 2 == 1 else n_pts - 1)
+    window_length = win if win >= 5 else (5 if n_pts >= 5 else n_pts)
+    if window_length >= 5:
+        y_vals = savgol_filter(df_sorted[dens_col].values, window_length, 2)
+        t_vals = savgol_filter(df_sorted[temp_col].values + 273.15, window_length, 2)
+    else:
+        y_vals = df_sorted[dens_col].values
+        t_vals = df_sorted[temp_col].values + 273.15
+
+    dTdt = np.gradient(t_vals, df_sorted[time_col].values)
+    dpdT = np.gradient(y_vals, t_vals)
+
+    interp_df = (
+        pd.DataFrame({"dens": y_vals, "T": t_vals, "dTdt": dTdt, "dpdT": dpdT})
+        .sort_values("dens")
+        .drop_duplicates("dens")
+    )
+    if len(interp_df) < 2:
+        raise ValueError("Dados insuficientes após filtragem para interpolação.")
+
+    f_T = interp1d(interp_df["dens"], interp_df["T"], kind="linear", bounds_error=False, fill_value="extrapolate")
+    f_dTdt = interp1d(interp_df["dens"], interp_df["dTdt"], kind="linear", bounds_error=False, fill_value="extrapolate")
+    f_dpdT = interp1d(interp_df["dens"], interp_df["dpdT"], kind="linear", bounds_error=False, fill_value="extrapolate")
+
+    return f_T, f_dTdt, f_dpdT
+
+
+def orlandini_araujo_filter(df: pd.DataFrame, bin_size: int = 10) -> pd.DataFrame:
+    """Apply the Orlandini-Araújo filter aggregating rows by time bins."""
+    time_col = next((c for c in df.columns if c.startswith("Time_s")), None)
+    temp_col = next((c for c in df.columns if c.startswith("Temperature_C")), None)
+    dens_col = next((c for c in df.columns if c.startswith("DensidadePct")), None)
+    if not (time_col and temp_col and dens_col):
+        raise ValueError(
+            "Faltam colunas (Time_s, Temperature_C, DensidadePct) para Orlandini-Araújo."
+        )
+
+    dfc = df.copy()
+    dfc["bin"] = np.floor(dfc[time_col] / bin_size).astype(int)
+    agg_dict = {col: "mean" for col in df.columns}
+    grouped = dfc.groupby("bin").agg(agg_dict).reset_index(drop=True)
+    return grouped
+
+
+__all__ = [
+    "normalize_columns",
+    "calculate_derivatives_robust",
+    "orlandini_araujo_filter",
+    "SinteringDataRecord",
+    "DataHistory",
+    "add_suffix_once",
+    "criar_titulo",
+    "exibir_mensagem",
+    "exibir_erro",
+    "criar_caixa_colapsavel",
+    "gerar_link_download",
+    "boltzmann_sigmoid",
+    "generalized_logistic_stable",
+]

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,4 +1,12 @@
 import importlib
- main
+import pytest
+
+MODULES = [
+    "ogum.ogum64",
+    "ogum.ogum72",
+    "ogum.ogum80",
+]
+
+@pytest.mark.parametrize("m", MODULES)
 def test_imports(m):
     assert importlib.import_module(m)


### PR DESCRIPTION
## Summary
- centralize data processing helpers in `utils`
- import helpers from `utils` in module code
- clean up imports and remove duplicated code
- fix malformed import tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dfe8933588327b239b2f6138d2e2e