### PR TITLE
Add utils filtering function and tests

### DIFF
--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,4 +1,13 @@
 import importlib
- main
-def test_imports(m):
-    assert importlib.import_module(m)
+import pytest
+
+
+@pytest.mark.parametrize(
+    "module",
+    [
+        "ogum.core",
+        "ogum.utils",
+    ],
+)
+def test_imports(module):
+    assert importlib.import_module(module)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,32 @@
+import pandas as pd
+import pytest
+
+from ogum import utils
+
+
+def test_normalize_columns_basic():
+    df = pd.DataFrame({"Tempo_s": [1, 2], "densidadepct": [0.1, 0.2]})
+    mapping = {"Time_s": ["tempo_s"], "DensidadePct": ["densidadepct"]}
+    result = utils.normalize_columns(df, mapping)
+    assert list(result.columns) == ["Time_s", "DensidadePct"]
+
+
+def test_orlandini_araujo_filter():
+    df = pd.DataFrame({
+        "Time_s": [0, 1, 2, 11, 12],
+        "Temperature_C": [100, 102, 101, 103, 104],
+        "DensidadePct": [10, 20, 30, 40, 50],
+    })
+    filtered = utils.orlandini_araujo_filter(df, bin_size=10)
+    expected = pd.DataFrame({
+        "Time_s": [1.0, 11.5],
+        "Temperature_C": [101.0, 103.5],
+        "DensidadePct": [20.0, 45.0],
+    })
+    pd.testing.assert_frame_equal(filtered.reset_index(drop=True), expected)
+
+
+def test_orlandini_missing_columns():
+    df = pd.DataFrame({"Time_s": [0], "Temperature_C": [100]})
+    with pytest.raises(ValueError):
+        utils.orlandini_araujo_filter(df)


### PR DESCRIPTION
## Summary
- fix broken imports test to use parameterized modules
- implement Orlandini-Araujo filter utility
- expose filter via `__all__`
- test `normalize_columns` and `orlandini_araujo_filter`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dfe666ec88327ad3ce4aeebcc96e7