### PR TITLE
Restore Orlandini–Araújo filter

### DIFF
--- a/ogum/ogum72.py
+++ b/ogum/ogum72.py
@@ -45,6 +45,7 @@ from scipy.integrate import cumulative_trapezoid as cumtrapz
 
 import sys
 import ogum.utils as core
+from ogum.utils import orlandini_araujo_filter
 sys.modules['ogum.core'] = core
 sys.modules['core'] = core
 

--- a/ogum/ogum80.py
+++ b/ogum/ogum80.py
@@ -34,6 +34,7 @@ import numpy as np
 import pandas as pd
 import ipywidgets as widgets
 from IPython.display import display, HTML
+from ogum.utils import orlandini_araujo_filter
 
 # Funções do SciPy
 from scipy.signal import savgol_filter


### PR DESCRIPTION
## Summary
- implement `orlandini_araujo_filter` utility
- expose filter from utils
- import the filter in `ogum72.py` and `ogum80.py`

## Testing
- `pytest -q` *(fails: IndentationError in tests/test_imports.py)*

------
https://chatgpt.com/codex/tasks/task_e_686dfe65ea2c832789e6c78e851812db