### PR TITLE
Add ImportError fallback for cumtrapz

### DIFF
--- a/ogum/ogum80.py
+++ b/ogum/ogum80.py
@@ -43,6 +43,19 @@ from scipy.stats import linregress
 # Exige scipy>=1.6 para a localização de cumtrapz em .integrate
 try:
     from scipy.integrate import cumtrapz
+except ImportError:
+    # Implementação alternativa de cumtrapz caso não esteja disponível
+    def cumtrapz(y, x=None, initial=0):
+        y = np.asarray(y)
+        if x is None:
+            x = np.arange(len(y))
+        else:
+            x = np.asarray(x)
+        res = [initial]
+        for i in range(1, len(y)):
+            trap = (y[i - 1] + y[i]) * (x[i] - x[i - 1]) / 2.0
+            res.append(res[-1] + trap)
+        return np.array(res)
 
 # ==============================================================================
 # Constantes Globais


### PR DESCRIPTION
## Summary
- add a fallback `cumtrapz` implementation in `ogum80.py` when `scipy.integrate` is unavailable

## Testing
- `python -m py_compile ogum/ogum80.py`
- `pytest -q` *(fails: IndentationError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_686dfe64edc08327a6545b8dc5b07a27