### PR TITLE
Add lint step using Ruff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          pip install ruff
+      - name: Lint
+        run: |
+          ruff check
+          ruff format --check
       - name: Run tests
         run: |
           pytest -q


### PR DESCRIPTION
## Summary
- add Ruff to dependencies
- run `ruff check` and `ruff format --check` before tests in CI

## Testing
- `ruff check` *(fails: many errors)*
- `pytest -q` *(fails: IndentationError in `ogum/utils.py`)*

------
https://chatgpt.com/codex/tasks/task_e_686e07b85be08327b408f783f25fa5af