### PR TITLE
Improve documentation for utils and modules

### DIFF
--- a/ogum/core.py
+++ b/ogum/core.py
@@ -44,9 +44,16 @@ class DataHistory:
     """Armazena versões de DataFrames para permitir desfazer operações."""
 
     def __init__(self) -> None:
+        """Initialize an empty history list."""
         self.history: List[Dict[str, Any]] = []
 
     def push(self, data: pd.DataFrame, module_name: str) -> None:
+        """Store a snapshot of ``data`` with metadata.
+
+        Args:
+            data (pd.DataFrame): DataFrame to be stored.
+            module_name (str): Name of the module originating the data.
+        """
         record = {
             "timestamp": datetime.datetime.now(),
             "module": module_name,
@@ -56,12 +63,29 @@ class DataHistory:
         self.history.append(record)
 
     def pop(self) -> Optional[Dict[str, Any]]:
+        """Remove and return the most recent entry.
+
+        Returns:
+            Optional[Dict[str, Any]]: The latest snapshot or ``None`` if
+            history is empty.
+        """
         return self.history.pop() if self.history else None
 
     def peek(self) -> Optional[Dict[str, Any]]:
+        """Return the most recent entry without removing it.
+
+        Returns:
+            Optional[Dict[str, Any]]: The latest snapshot or ``None`` if
+            history is empty.
+        """
         return self.history[-1] if self.history else None
 
     def get_all(self) -> List[Dict[str, Any]]:
+        """Return a copy of the entire history.
+
+        Returns:
+            List[Dict[str, Any]]: All stored snapshots.
+        """
         return list(self.history)
 
 # ---------------------------------------------------------------------------
@@ -79,16 +103,37 @@ def criar_titulo(texto: str, nivel: int = 2) -> widgets.HTML:
 
 
 def exibir_mensagem(msg: str) -> None:
+    """Display a blue informational message in the notebook output.
+
+    Args:
+        msg (str): Message to be shown.
+    """
     display(HTML(f"<p style='color:blue; font-style:italic;'>{msg}</p>"))
 
 
 def exibir_erro(msg: str) -> None:
+    """Display an error message in bold red text.
+
+    Args:
+        msg (str): Message describing the error.
+    """
     display(HTML(f"<p style='color:red; font-weight:bold;'>ERRO: {msg}</p>"))
 
 
 def criar_caixa_colapsavel(
     titulo: str, conteudo: widgets.Widget, aberto: bool = False
 ) -> widgets.Accordion:
+    """Return an accordion widget with optional collapsed state.
+
+    Args:
+        titulo (str): Title shown on the accordion tab.
+        conteudo (widgets.Widget): Widget displayed inside the accordion.
+        aberto (bool, optional): Whether the accordion starts opened.
+            Defaults to ``False``.
+
+    Returns:
+        widgets.Accordion: Configured accordion widget.
+    """
     acc = widgets.Accordion(children=[conteudo])
     acc.set_title(0, titulo)
     if not aberto:
@@ -116,11 +161,36 @@ def gerar_link_download(df: pd.DataFrame, nome_arquivo: str = "dados.xlsx") -> H
 # ---------------------------------------------------------------------------
 
 def boltzmann_sigmoid(x, A1, A2, x0, dx):
+    """Compute a Boltzmann sigmoidal curve.
+
+    Args:
+        x: Independent variable.
+        A1: Lower asymptote.
+        A2: Upper asymptote.
+        x0: Center of the transition.
+        dx: Slope factor.
+
+    Returns:
+        np.ndarray: Evaluated sigmoid values.
+    """
     exp_term = np.exp(np.clip((x - x0) / dx, -700, 700))
     return A2 + (A1 - A2) / (1 + exp_term)
 
 
 def generalized_logistic_stable(x, A1, A2, x0, b, c):
+    """Stable generalized logistic function used to fit sigmoidal data.
+
+    Args:
+        x: Independent variable.
+        A1: Lower asymptote.
+        A2: Upper asymptote.
+        x0: Location parameter.
+        b: Scale parameter.
+        c: Asymmetry parameter.
+
+    Returns:
+        np.ndarray: Evaluated logistic values.
+    """
     z = -(x - x0) / b
     log_1_plus_exp_z = np.where(z > 30, z, np.log1p(np.exp(z)))
     denominator = np.exp(c * log_1_plus_exp_z)

--- a/ogum/fzea.py
+++ b/ogum/fzea.py
@@ -24,10 +24,25 @@ from ipywidgets import Layout
 # 2. DEFINIÇÃO DA FUNÇÃO DE PROCESSAMENTO (VERSÃO FINAL 6.0 - COM DEBUG)
 # ==============================================================================
 
-def final_parse_and_process_flash_data(file_content, diametro_mm, espessura_inicial_mm, espessura_final_mm, debug_mode=False):
-    """
-    Versão Final 6.0: Inclui um modo de depuração (debug_mode) para imprimir
-    logs detalhados do processo de parsing e validação.
+def final_parse_and_process_flash_data(
+    file_content,
+    diametro_mm,
+    espessura_inicial_mm,
+    espessura_final_mm,
+    debug_mode=False,
+):
+    """Parse and process raw flash-sintering data.
+
+    Args:
+        file_content (bytes): Raw ``.txt`` content.
+        diametro_mm (float): Sample diameter in millimetres.
+        espessura_inicial_mm (float): Initial thickness in millimetres.
+        espessura_final_mm (float): Final thickness in millimetres.
+        debug_mode (bool, optional): Whether to collect debug messages.
+
+    Returns:
+        tuple[pd.DataFrame, str] | tuple[None, str]: Processed data and the log
+        output. If processing fails, the first element is ``None``.
     """
     log_messages = []
     def log(message):
@@ -178,6 +193,7 @@ export_output = widgets.Output()
 processed_df = None
 
 def on_process_button_clicked(b):
+    """Process the uploaded file and store the resulting DataFrame."""
     global processed_df
     status_output.clear_output(); graphs_output.clear_output(); export_output.clear_output()
     with status_output:
@@ -202,6 +218,7 @@ def on_process_button_clicked(b):
             print(f"\n✔ Processamento concluído! {len(df)} pontos na faixa de interesse.")
 
 def create_download_link(df):
+    """Display a download link for the processed DataFrame as CSV."""
     original_filename = list(uploader.value.keys())[0].replace('.txt', '')
     download_filename = f"Resultados_Auto_{original_filename}.csv"
     df_to_export = df.copy()
@@ -212,6 +229,7 @@ def create_download_link(df):
     display(HTML(link))
 
 def on_basic_graphs_clicked(b):
+    """Plot basic analysis graphs using ``processed_df``."""
     with graphs_output:
         graphs_output.clear_output()
         if processed_df is None: print("Por favor, processe os dados primeiro."); return
@@ -225,6 +243,7 @@ def on_basic_graphs_clicked(b):
         plt.tight_layout(rect=[0, 0.03, 1, 0.95]); plt.show()
 
 def on_adv_graphs_clicked(b):
+    """Plot additional analysis graphs using ``processed_df``."""
     with graphs_output:
         graphs_output.clear_output()
         if processed_df is None: print("Por favor, processe os dados primeiro."); return
@@ -238,6 +257,7 @@ def on_adv_graphs_clicked(b):
         plt.tight_layout(rect=[0, 0.03, 1, 0.95]); plt.show()
 
 def on_export_button_clicked(b):
+    """Provide a download link for the processed results."""
     with export_output:
         export_output.clear_output()
         if processed_df is None: print("Por favor, processe os dados primeiro."); return
@@ -255,5 +275,4 @@ input_box = widgets.VBox([uploader, widgets.HBox([diametro_input, esp_inicial_in
 action_box = widgets.VBox([process_button, export_button])
 graphs_buttons_box = widgets.HBox([basic_graphs_button, adv_graphs_button])
 title = widgets.HTML("<h3>Aplicação Final para Análise de Dados de Flash Sintering (v6.0 - com Debug)</h3>")
-
 display(widgets.VBox([title, widgets.HBox([input_box, action_box]), status_output, graphs_buttons_box, graphs_output, export_output]))

--- a/ogum/ogum64.py
+++ b/ogum/ogum64.py
@@ -365,6 +365,14 @@ class Modulo2Importacao:
 # =================================================================================
 
     def _on_confirm_mapping(self, idx):
+        """Create and validate column mappings for a given test.
+
+        Args:
+            idx (int): Index of the test being mapped.
+
+        Returns:
+            Callable: Callback used by the confirm button.
+        """
         def callback(b):
             w = self.file_uploads[idx]
             out_local = w["out_local"]
@@ -989,6 +997,7 @@ proceed_button = widgets.Button(description="Realizar Ação", button_style='suc
 out = widgets.Output()
 
 def on_proceed_clicked(b):
+    """Handle the final method selection and hide the chooser UI."""
     with out:
         clear_output()
         choice = method_radio.value

--- a/ogum/ogum72.py
+++ b/ogum/ogum72.py
@@ -265,6 +265,14 @@ class Modulo2Importacao:
         w["map_confirm_btn"].layout.display = ''
 
     def _on_confirm_mapping(self, idx):
+        """Validate mapping selections and rename columns for a given test.
+
+        Args:
+            idx (int): Index of the test being processed.
+
+        Returns:
+            Callable: Callback bound to the confirmation button.
+        """
         def _cb(_):
             w = self.file_uploads[idx]
             with w["out_local"]:
@@ -640,6 +648,7 @@ proceed_button = widgets.Button(description="Realizar Ação", button_style='suc
 out = widgets.Output()
 
 def on_proceed_clicked(b):
+    """Handle the method selection and hide the choice interface."""
     with out:
         clear_output()
         choice = method_radio.value

--- a/ogum/ogum80.py
+++ b/ogum/ogum80.py
@@ -45,17 +45,8 @@ from scipy.stats import linregress
 try:
     from scipy.integrate import cumtrapz
 
-    def cumtrapz(y, x=None, initial=0):
-        y = np.asarray(y)
-        if x is None:
-            x = np.arange(len(y))
-        else:
-            x = np.asarray(x)
-        res = [initial]
-        for i in range(1, len(y)):
-
-            res.append(res[-1] + trap)
-        return np.array(res)
+except ImportError:  # pragma: no cover - older scipy
+    from scipy.integrate import cumulative_trapezoid as cumtrapz
 
 # ==============================================================================
 # Constantes Globais
@@ -269,6 +260,14 @@ class Modulo2Importacao:
         w["map_confirm_btn"].layout.display = ''
 
     def _on_confirm_mapping(self, idx):
+        """Validate mapping selections and rename columns for a given test.
+
+        Args:
+            idx (int): Index of the test being processed.
+
+        Returns:
+            Callable: Callback bound to the confirmation button.
+        """
         def _cb(_):
             w = self.file_uploads[idx]
             with w["out_local"]:
@@ -821,6 +820,7 @@ proceed_button = widgets.Button(description="Realizar Ação", button_style='suc
 out = widgets.Output()
 
 def on_proceed_clicked(b):
+    """Handle the method selection and hide the choice interface."""
     with out:
         clear_output()
         choice = method_radio.value

--- a/ogum/utils.py
+++ b/ogum/utils.py
@@ -1,19 +1,23 @@
 """Small helper utilities used across the code base."""
 from __future__ import annotations
 
+from typing import Dict, Iterable
 
+import numpy as np
+import pandas as pd
 
 
 def normalize_columns(df: pd.DataFrame, mapping: Dict[str, Iterable[str]]) -> pd.DataFrame:
-    """Return a DataFrame with columns renamed based on a mapping.
+    """Rename DataFrame columns based on a mapping of possible names.
 
-    Parameters
-    ----------
-    df:
-        DataFrame cujos nomes de colunas serão normalizados.
-    mapping:
-        Dicionário onde a chave é o nome desejado e o valor é uma lista
-        de nomes possíveis (case insensitive) encontrados em ``df``.
+    Args:
+        df (pd.DataFrame): DataFrame whose columns will be normalized.
+        mapping (Dict[str, Iterable[str]]): Dictionary where keys are desired
+            names and values are lists of possible (case-insensitive) column
+            names found in ``df``.
+
+    Returns:
+        pd.DataFrame: DataFrame with standardized column names.
     """
     rename_dict = {}
     for col in df.columns:
@@ -25,9 +29,29 @@ def normalize_columns(df: pd.DataFrame, mapping: Dict[str, Iterable[str]]) -> pd
     return df.rename(columns=rename_dict)
 
 
+def orlandini_araujo_filter(df: pd.DataFrame, bin_size: int = 10) -> pd.DataFrame:
+    """Apply the Orlandini-Araújo filter aggregating rows by time bins.
 
+    Args:
+        df (pd.DataFrame): Input DataFrame with ``Time_s``, ``Temperature_C``
+            and ``DensidadePct`` columns.
+        bin_size (int, optional): Bin width in seconds. Defaults to ``10``.
+
+    Returns:
+        pd.DataFrame: Filtered DataFrame.
+    """
+    time_col = next((c for c in df.columns if c.startswith("Time_s")), None)
+    temp_col = next((c for c in df.columns if c.startswith("Temperature_C")), None)
+    dens_col = next((c for c in df.columns if c.startswith("DensidadePct")), None)
+    if not (time_col and temp_col and dens_col):
+        raise ValueError(
+            "Faltam colunas (Time_s, Temperature_C, DensidadePct) para Orlandini-Araújo."
         )
 
     dfc = df.copy()
     dfc["bin"] = np.floor(dfc[time_col] / bin_size).astype(int)
+    agg_dict = {col: "mean" for col in df.columns}
+    grouped = dfc.groupby("bin").agg(agg_dict).reset_index(drop=True)
+    return grouped
 
+__all__ = ["normalize_columns", "orlandini_araujo_filter"]


### PR DESCRIPTION
## Summary
- document `DataHistory` methods and helper functions
- rewrite utility module with missing filtering helper
- add docs for mapping callbacks in notebooks
- expand docstrings in flash sintering routines

## Testing
- `python -m py_compile ogum/core.py ogum/utils.py ogum/ogum64.py ogum/ogum72.py ogum/ogum80.py ogum/fzea.py ogum/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e07b2e1088327bd3d322821a7f65c