### PR TITLE
Add SOVS solver

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ funções auxiliares simples, como `normalize_columns`, utilizadas por diferente
 experimentos. Manter esse arquivo presente permite que os scripts exportados
 funcionem sem ajustes adicionais e compartilhem a mesma base de utilidades.
 
+O módulo `ogum/sovs.py` fornece `SOVSSolver`, um integrador baseado no modelo
+de Skorohod-Olevsky. Instancie-o com os parâmetros do material e utilize
+``solve(t, T)`` para obter a evolução da densidade relativa ao longo do tempo.
+
 ## Estilo & Lint
 O projeto utiliza o [Ruff](https://docs.astral.sh/ruff/) tanto para lint quanto
 para formatação de código, substituindo o Black tradicional. Para checar se o

--- a/ogum/__init__.py
+++ b/ogum/__init__.py
@@ -12,6 +12,7 @@ from .core import (
     gerar_link_download,
     boltzmann_sigmoid,
     generalized_logistic_stable,
+    SOVSSolver,
 )
 from .utils import normalize_columns, orlandini_araujo_filter
 
@@ -27,6 +28,7 @@ __all__ = [
     "gerar_link_download",
     "boltzmann_sigmoid",
     "generalized_logistic_stable",
+    "SOVSSolver",
     "normalize_columns",
     "orlandini_araujo_filter",
 ]

--- a/ogum/core.py
+++ b/ogum/core.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from .utils import normalize_columns
+from .sovs import SOVSSolver
 
 import numpy as np
 import pandas as pd
@@ -207,5 +208,6 @@ __all__ = [
     "gerar_link_download",
     "boltzmann_sigmoid",
     "generalized_logistic_stable",
+    "SOVSSolver",
     "normalize_columns",
 ]

--- a/ogum/sovs.py
+++ b/ogum/sovs.py
@@ -1,0 +1,82 @@
+"""Sintering solver based on the Skorohod-Olevsky viscous sintering model."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.integrate import solve_ivp
+
+from .core import R
+
+
+class SOVSSolver:
+    """Simple numerical solver for the SOVS densification model.
+
+    Parameters
+    ----------
+    Ea:
+        Activation energy in J/mol.
+    A:
+        Pre-exponential factor with units 1/s.
+    m:
+        Exponent of the densification term. Defaults to 1.
+    rho0:
+        Initial relative density in the range 0--1.
+    R_const:
+        Gas constant used in the Arrhenius term. Defaults to
+        :data:`ogum.core.R`.
+    """
+
+    def __init__(self, Ea: float, A: float, m: float = 1.0, rho0: float = 0.6, R_const: float = R) -> None:
+        self.Ea = Ea
+        self.A = A
+        self.m = m
+        self.rho0 = rho0
+        self.R_const = R_const
+        self._t_profile: np.ndarray | None = None
+        self._T_profile: np.ndarray | None = None
+
+    # ------------------------------------------------------------------
+    def _interp_T(self, t: float) -> float:
+        assert self._t_profile is not None
+        assert self._T_profile is not None
+        return float(np.interp(t, self._t_profile, self._T_profile))
+
+    def _ode(self, t: float, y: np.ndarray) -> np.ndarray:
+        rho = y[0]
+        T = self._interp_T(t)
+        rate = self.A * np.exp(-self.Ea / (self.R_const * T)) * (1.0 - rho) ** self.m
+        return np.array([rate])
+
+    # ------------------------------------------------------------------
+    def solve(self, t: np.ndarray, T: np.ndarray) -> np.ndarray:
+        """Solve the densification ODE for a time--temperature profile.
+
+        Parameters
+        ----------
+        t:
+            1D array with the time points in seconds.
+        T:
+            1D array with the temperature values in Kelvin at each time in
+            ``t``.
+
+        Returns
+        -------
+        numpy.ndarray
+            Array of relative densities evaluated at ``t``.
+        """
+
+        t = np.asarray(t, dtype=float)
+        T = np.asarray(T, dtype=float)
+        if t.shape != T.shape:
+            raise ValueError("t and T must have the same shape")
+        if t.ndim != 1:
+            raise ValueError("t and T must be one-dimensional")
+
+        self._t_profile = t
+        self._T_profile = T
+
+        sol = solve_ivp(self._ode, (float(t[0]), float(t[-1])), np.array([self.rho0]), t_eval=t, vectorized=False)
+        return sol.y[0]
+
+
+__all__ = ["SOVSSolver"]

--- a/tests/test_sovs.py
+++ b/tests/test_sovs.py
@@ -1,0 +1,15 @@
+import numpy as np
+
+from ogum.sovs import SOVSSolver
+
+
+def test_constant_temperature_profile():
+    solver = SOVSSolver(Ea=1e5, A=1.0, rho0=0.5)
+    t = np.linspace(0.0, 10.0, 11)
+    T = np.full_like(t, 1000.0)
+    rho = solver.solve(t, T)
+
+    assert isinstance(rho, np.ndarray)
+    assert rho.shape == t.shape
+    # density should increase monotonically
+    assert np.all(np.diff(rho) > 0)


### PR DESCRIPTION
## Summary
- implement `ogum.sovs` with `SOVSSolver`
- expose `SOVSSolver` in `core` and package `__init__`
- document solver usage in README
- provide basic unit test for solver

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686e13bb5cb08327a2565db3debe01c5