### PR TITLE
Add FEM stub and workflow update

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,5 +18,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+      - name: FEM import
+        run: pip install fenicsx-dolfinx
       - name: Run tests
         run: pytest -q

--- a/README.md
+++ b/README.md
@@ -60,3 +60,6 @@ Já a formatação pode ser aplicada com o Black embutido no Ruff:
 ```bash
 ruff format .
 ```
+
+## Stub FEM
+O arquivo `ogum/fem_interface.py` define a função `create_unit_mesh`, que apenas importa o construtor de malha do FEniCSx. Essa implementação é provisória e servirá de base para integrações futuras com um solver de Elementos Finitos.

--- a/ogum/fem_interface.py
+++ b/ogum/fem_interface.py
@@ -1,0 +1,15 @@
+from typing import Any
+
+
+def create_unit_mesh(mesh_size: float) -> Any:
+    """Create a simple unit mesh using FEniCSx.
+
+    Args:
+        mesh_size: Desired element size of the mesh.
+
+    Returns:
+        A mesh object from FEniCSx.
+    """
+    from fenicsx.mesh import create_unit_square  # type: ignore
+    # TODO: implement proper mesh generation
+    pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pandas
 matplotlib
 pytest
 openpyxl
+# Optional: fenicsx-dolfinx for FEM simulations

--- a/tests/test_fem.py
+++ b/tests/test_fem.py
@@ -1,0 +1,12 @@
+import importlib
+import pytest
+
+import ogum.fem_interface as fem
+
+
+def test_fem_stub():
+    if importlib.util.find_spec("fenicsx") is None:
+        with pytest.raises(ModuleNotFoundError):
+            fem.create_unit_mesh(1.0)
+    else:
+        fem.create_unit_mesh(1.0)


### PR DESCRIPTION
## Summary
- stub out `create_unit_mesh` in new module `fem_interface`
- allow optional installation of fenicsx-dolfinx in CI
- add minimal test for FEM interface
- document optional dependency
- describe FEM stub in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686e860a2c2c8327919356d18e4d3fd4