### PR TITLE
Refactor Ruff config layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,10 @@
 [tool.ruff]
 line-length = 120
-lint.select = ["E4", "E7", "E9", "F"]
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
 extend-select = ["D"]
 pydocstyle.convention = "google"
 
 [tool.ruff.format]
-line-length = 120
+


### PR DESCRIPTION
## Summary
- restructure `pyproject.toml` to use `[tool.ruff.lint]`
- keep the formatting table in place

## Testing
- `pytest -q`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_686e8b2048d48327a9e0f79489eb736e