### PR TITLE
Configure ruff settings

### DIFF
--- a/ogum/fem_interface.py
+++ b/ogum/fem_interface.py
@@ -10,4 +10,5 @@ def create_unit_mesh(mesh_size: float) -> Any:
     Returns:
         A mesh object from FEniCSx.
     """
+    raise NotImplementedError("FEM functionality is not yet implemented.")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [tool.ruff]
-line-length = 120
+line-length = 88
+exclude = ["ogum/ogum64.py", "ogum/ogum72.py", "ogum/ogum80.py", "ogum/fzea.py"]
 
 [tool.ruff.lint]
 select = ["E4", "E7", "E9", "F"]

--- a/tests/test_fem.py
+++ b/tests/test_fem.py
@@ -4,4 +4,5 @@ from ogum.fem_interface import create_unit_mesh
 
 
 def test_fem_stub():
-
+    with pytest.raises(NotImplementedError):
+        create_unit_mesh(1.0)


### PR DESCRIPTION
## Summary
- set Ruff line length to 88
- exclude auto-generated modules from Ruff checks
- restore FEM stub and corresponding test so test suite runs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686eca522cb08327bcf690ac92a89871