### PR TITLE
Fix orphan function code

### DIFF
--- a/ogum/core.py
+++ b/ogum/core.py
@@ -131,6 +131,10 @@ def exibir_erro(msg: str) -> None:
 
 
 
+def criar_caixa_colapsavel(
+    titulo: str, conteudo: widgets.Widget, aberto: bool = False
+) -> widgets.Accordion:
+    """Return a collapsible Accordion widget."""
     acc = widgets.Accordion(children=[conteudo])
     acc.set_title(0, titulo)
     if not aberto:

--- a/tests/test_fem.py
+++ b/tests/test_fem.py
@@ -4,4 +4,4 @@ from ogum.fem_interface import create_unit_mesh
 
 
 def test_fem_stub():
-
+    pass


### PR DESCRIPTION
## Summary
- define `criar_caixa_colapsavel` and place it after `exibir_erro`
- fix syntax error in tests by adding body to `test_fem_stub`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686eca518de4832788e4534ccd0ee3c3