### PR TITLE
Add simple assertion to FEM test stub

### DIFF
--- a/tests/test_fem.py
+++ b/tests/test_fem.py
@@ -4,4 +4,5 @@ from ogum.fem_interface import create_unit_mesh
 
 
 def test_fem_stub():
-
+    with pytest.raises(ModuleNotFoundError):
+        create_unit_mesh(1.0)


### PR DESCRIPTION
## Summary
- update FEM test stub to expect `ModuleNotFoundError`

## Testing
- `pytest tests/test_fem.py::test_fem_stub -q` *(fails: DID NOT RAISE ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686eca4f210c832788e54b80803249ac