### PR TITLE
Implement optional FEniCSx mesh creation

### DIFF
--- a/ogum/fem_interface.py
+++ b/ogum/fem_interface.py
@@ -2,6 +2,16 @@
 
 from typing import Any
 
+try:  # pragma: no cover - optional dependency
+    from dolfinx.mesh import create_rectangle, CellType
+    from mpi4py import MPI
+    import numpy as np
+except Exception:  # pragma: no cover - optional dependency
+    create_rectangle = None  # type: ignore
+    CellType = None  # type: ignore
+    MPI = None  # type: ignore
+    np = None  # type: ignore
+
 
 def create_unit_mesh(mesh_size: float) -> Any:
     """Create a simple unit mesh using FEniCSx.
@@ -12,4 +22,19 @@ def create_unit_mesh(mesh_size: float) -> Any:
     Returns:
         A mesh object from FEniCSx.
     """
-    raise ModuleNotFoundError("fenicsx not installed")
+    try:
+        if None in {create_rectangle, CellType, MPI, np}:
+            raise ImportError
+
+        n = int(1 / mesh_size)
+        if n < 1:
+            n = 1
+
+        return create_rectangle(
+            MPI.COMM_WORLD,
+            np.array([[0, 0], [1, 1]], dtype=float),
+            [n, n],
+            CellType.triangle,
+        )
+    except ImportError as exc:
+        raise ModuleNotFoundError("fenicsx not installed") from exc


### PR DESCRIPTION
## Summary
- enhance `fem_interface` to attempt using FEniCSx when available
- add optional imports and create a functional `create_unit_mesh`

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f19c62ed08327b651e7711f6d091c