### PR TITLE
Handle missing FEniCSx imports

### DIFF
--- a/ogum/fem_interface.py
+++ b/ogum/fem_interface.py
@@ -1,6 +1,4 @@
 from typing import Any
-from mpi4py import MPI
-from dolfinx.mesh import create_rectangle, CellType
 
 def create_unit_mesh(mesh_size: float) -> Any:
     """
@@ -12,6 +10,12 @@ def create_unit_mesh(mesh_size: float) -> Any:
     Returns:
         Mesh do Dolfinx.
     """
+    try:
+        from mpi4py import MPI
+        from dolfinx.mesh import create_rectangle, CellType
+    except ImportError as exc:
+        raise ModuleNotFoundError("FEniCSx ou mpi4py não instalado") from exc
+
     domain = [[0.0, 0.0], [1.0, 1.0]]
     n = max(1, int(1.0 / mesh_size))
     mesh = create_rectangle(MPI.COMM_WORLD, domain, [n, n], CellType.triangle)


### PR DESCRIPTION
## Summary
- defer mpi4py and dolfinx imports inside `create_unit_mesh`
- handle missing FEM dependencies gracefully

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686fddabc66c832786458de9ed31fa47