### PR TITLE
Add FastAPI filter endpoint and tests

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import List
+
+import numpy as np
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from core.solver import apply_savitzky_golay_filter
+
+app = FastAPI()
+
+
+class FilterRequest(BaseModel):
+    """Request body for the Savitzky-Golay filter."""
+
+    data_points: List[float]
+    window_length: int
+    polyorder: int
+
+
+class FilterResponse(BaseModel):
+    """Response containing original and filtered data."""
+
+    original_data: List[float]
+    filtered_data: List[float]
+
+
+@app.post("/processing/filter", response_model=FilterResponse)
+def process_filter(request: FilterRequest) -> FilterResponse:
+    """Apply Savitzky-Golay filter to ``request.data_points``."""
+    if request.window_length <= 0 or request.window_length % 2 == 0:
+        raise HTTPException(status_code=400, detail="window_length must be a positive odd integer")
+
+    data_array = np.array(request.data_points, dtype=float)
+    filtered = apply_savitzky_golay_filter(
+        data_array, window_length=request.window_length, polyorder=request.polyorder
+    )
+    return FilterResponse(original_data=request.data_points, filtered_data=filtered.tolist())

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,21 @@
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+client = TestClient(app)
+
+
+def test_filter_endpoint_success():
+    payload = {"data_points": [1.0, 2.0, 3.0, 4.0, 5.0], "window_length": 3, "polyorder": 1}
+    response = client.post("/processing/filter", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["original_data"] == payload["data_points"]
+    assert isinstance(data["filtered_data"], list)
+    assert len(data["filtered_data"]) == len(payload["data_points"])
+
+
+def test_filter_endpoint_invalid_window():
+    payload = {"data_points": [1, 2, 3, 4], "window_length": 4, "polyorder": 1}
+    response = client.post("/processing/filter", json=payload)
+    assert response.status_code == 400


### PR DESCRIPTION
## Summary
- add FastAPI app exposing Savitzky–Golay filter
- validate odd window length
- test API filter route

## Testing
- `ruff check .` *(fails: D104, D100, ...)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_686fe2fc54ac83279711a6d943889dd0