### PR TITLE
Update dependency docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ pip install -r requirements.txt
 pytest -q
 ```
 
-Alguns testes de FEM exigem numpy, pandas e fenicsx-dolfinx:
+Alguns testes de FEM e da API exigem dependências extras:
 
 ```bash
-pip install numpy pandas fenicsx-dolfinx
+pip install fenicsx-dolfinx fastapi httpx
 ```
 
 ## Estrutura do código

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,6 @@ pandas
 matplotlib
 pytest
 openpyxl
-# Optional: numpy, pandas, fenicsx-dolfinx for FEM/tests
+fastapi
+httpx
+fenicsx-dolfinx


### PR DESCRIPTION
## Summary
- document extra dependencies for API and FEM tests in README
- list fastapi, httpx and fenicsx-dolfinx in requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686feb35ee088327ab0d686dcc19db73