### PR TITLE
Fix fem_interface docstring style

### DIFF
--- a/ogum/fem_interface.py
+++ b/ogum/fem_interface.py
@@ -1,8 +1,8 @@
 from typing import Any
 
+
 def create_unit_mesh(mesh_size: float) -> Any:
-    """
-    Gera uma malha unitária quadrada de passo `mesh_size` usando FEniCSx.
+    """Gera uma malha unitária quadrada de passo `mesh_size` usando FEniCSx.
 
     Args:
         mesh_size: tamanho do elemento de malha (ex.: 0.1 para 10×10 células).


### PR DESCRIPTION
## Summary
- adjust opening triple-quote for `create_unit_mesh` docstring

## Testing
- `ruff check ogum/fem_interface.py --extend-ignore D100`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686feb3764d883278c4564db2f2d12a3