### PR TITLE
Add FEM API router with background tasks

### DIFF
--- a/api/fem_router.py
+++ b/api/fem_router.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import uuid
+from typing import Dict
+
+from fastapi import APIRouter, BackgroundTasks, status
+from pydantic import BaseModel
+
+from fem.solver import run_fem_simulation
+
+router = APIRouter(prefix="/fem")
+
+
+class FemSimulationRequest(BaseModel):
+    mesh_params: Dict[str, float]
+    material_params: Dict[str, float]
+    bc_params: Dict[str, float]
+
+
+@router.post("/simulation", status_code=status.HTTP_202_ACCEPTED)
+def start_fem_simulation(
+    request: FemSimulationRequest, background_tasks: BackgroundTasks
+) -> dict[str, str]:
+    job_id = str(uuid.uuid4())
+    output_name = f"fem_output/{job_id}.xdmf"
+    background_tasks.add_task(
+        run_fem_simulation,
+        request.mesh_params,
+        request.material_params,
+        request.bc_params,
+        output_name,
+    )
+    return {
+        "message": "FEM simulation started in the background.",
+        "job_id": job_id,
+    }

--- a/api/main.py
+++ b/api/main.py
@@ -6,9 +6,12 @@ import numpy as np
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
+from api.fem_router import router as fem_router
+
 from core.solver import apply_savitzky_golay_filter, calculate_activation_energy
 
 app = FastAPI()
+app.include_router(fem_router)
 
 
 class FilterRequest(BaseModel):


### PR DESCRIPTION
## Summary
- refactor fem solver into `run_fem_simulation`
- add `api.fem_router` with background task endpoint
- register the new router in the FastAPI app

## Testing
- `ruff check .`
- `ruff format --check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_686fee611c008327858f602ee36dcb68