### PR TITLE
Add FEM job polling

### DIFF
--- a/api/fem_router.py
+++ b/api/fem_router.py
@@ -5,6 +5,8 @@ from typing import Dict
 
 from fastapi import APIRouter, BackgroundTasks, status
 from pydantic import BaseModel
+import json
+from pathlib import Path
 
 from fem.solver import run_fem_simulation
 
@@ -29,8 +31,18 @@ def start_fem_simulation(
         request.material_params,
         request.bc_params,
         output_name,
+        job_id,
     )
     return {
         "message": "FEM simulation started in the background.",
         "job_id": job_id,
     }
+
+
+@router.get("/simulation/status/{job_id}")
+def fem_simulation_status(job_id: str) -> dict[str, str]:
+    status_file = Path(f"fem_output/{job_id}.json")
+    if not status_file.exists():
+        return {"status": "pending"}
+    with status_file.open() as f:
+        return json.load(f)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,7 @@
 from fastapi.testclient import TestClient
 import numpy as np
+import json
+from pathlib import Path
 
 from api.main import app
 
@@ -7,7 +9,11 @@ client = TestClient(app)
 
 
 def test_filter_endpoint_success():
-    payload = {"data_points": [1.0, 2.0, 3.0, 4.0, 5.0], "window_length": 3, "polyorder": 1}
+    payload = {
+        "data_points": [1.0, 2.0, 3.0, 4.0, 5.0],
+        "window_length": 3,
+        "polyorder": 1,
+    }
     response = client.post("/processing/filter", json=payload)
     assert response.status_code == 200
     data = response.json()
@@ -39,3 +45,23 @@ def test_activation_energy_endpoint_mismatch():
     payload = {"temperatures": [300.0, 400.0], "rates": [1.0]}
     response = client.post("/processing/activation-energy", json=payload)
     assert response.status_code == 400
+
+
+def test_fem_status_pending(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    job_id = "missing"
+    resp = client.get(f"/fem/simulation/status/{job_id}")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "pending"}
+
+
+def test_fem_status_existing(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    job_id = "abc"
+    out_dir = Path("fem_output")
+    out_dir.mkdir()
+    data = {"status": "completed", "image_path": "img.png", "data_path": "file.xdmf"}
+    (out_dir / f"{job_id}.json").write_text(json.dumps(data))
+    resp = client.get(f"/fem/simulation/status/{job_id}")
+    assert resp.status_code == 200
+    assert resp.json() == data


### PR DESCRIPTION
## Summary
- track FEM solver status in `fem_output/{job_id}.json`
- expose `/fem/simulation/status/{job_id}` endpoint
- poll for completion from the streamlit UI
- test pending/completed status handling

## Testing
- `ruff format app/ui.py api/fem_router.py fem/solver.py tests/test_api.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_686ff3f1c48883278055321caa999389