### PR TITLE
Add time params to FEM request

### DIFF
--- a/api/fem_router.py
+++ b/api/fem_router.py
@@ -17,6 +17,8 @@ class FemSimulationRequest(BaseModel):
     mesh_params: Dict[str, float]
     material_params: Dict[str, float]
     bc_params: Dict[str, float]
+    total_time: float
+    num_steps: int
 
 
 @router.post("/simulation", status_code=status.HTTP_202_ACCEPTED)
@@ -32,6 +34,8 @@ def start_fem_simulation(
         request.bc_params,
         output_name,
         job_id,
+        request.total_time,
+        request.num_steps,
     )
     return {
         "message": "FEM simulation started in the background.",


### PR DESCRIPTION
## Summary
- extend `FemSimulationRequest` with `total_time` and `num_steps`
- pass new parameters to `run_fem_simulation`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_687003cc89008327892f07a0616ebbe2