### PR TITLE
Add material calibrator module

### DIFF
--- a/ogum/__init__.py
+++ b/ogum/__init__.py
@@ -15,6 +15,7 @@ from .core import (
 )
 from .utils import normalize_columns, orlandini_araujo_filter
 from .processing import calculate_log_theta
+from .material_calibrator import MaterialCalibrator
 
 __all__ = [
     "R",
@@ -31,4 +32,5 @@ __all__ = [
     "normalize_columns",
     "orlandini_araujo_filter",
     "calculate_log_theta",
+    "MaterialCalibrator",
 ]

--- a/ogum/material_calibrator.py
+++ b/ogum/material_calibrator.py
@@ -1,0 +1,128 @@
+"""Tools for calibrating material kinetics from flash sintering experiments."""
+# ruff: noqa: D416
+
+from __future__ import annotations
+
+from typing import List, Tuple, Union
+
+import numpy as np
+import pandas as pd
+
+from .core import R
+from .processing import calculate_log_theta
+
+
+class MaterialCalibrator:
+    """Calibrate activation energy and pre--exponential factor.
+
+    Parameters
+    ----------
+    experiments : Union[pd.DataFrame, List[pd.DataFrame]]
+        One or more experimental datasets with columns ``Time_s``,
+        ``Temperature_C`` and ``DensidadePct``.
+    """
+
+    def __init__(self, experiments: Union[pd.DataFrame, List[pd.DataFrame]]) -> None:
+        """Store experiment data.
+
+        Parameters
+        ----------
+        experiments
+            Single DataFrame or list of DataFrames containing the experimental
+            columns.
+        """
+        if isinstance(experiments, pd.DataFrame):
+            self.experiments = [experiments]
+        else:
+            self.experiments = list(experiments)
+
+    @staticmethod
+    def fit(experiments: Union[pd.DataFrame, List[pd.DataFrame]]) -> Tuple[float, float]:
+        """Return ``(Ea_kj, A)`` fitted from the provided experiments.
+
+        The regression is performed on ``ln(dens_rate / (1-x))`` versus ``1/T``,
+        assuming first-order kinetics.
+
+        Parameters
+        ----------
+        experiments
+            List of DataFrames or a single DataFrame as accepted by
+            :class:`MaterialCalibrator`.
+
+        Returns
+        -------
+        Tuple[float, float]
+            Estimated activation energy in kJ/mol and pre-exponential factor.
+        """
+        exps = [experiments] if isinstance(experiments, pd.DataFrame) else list(experiments)
+        xs: List[np.ndarray] = []
+        ys: List[np.ndarray] = []
+
+        for df in exps:
+            t = df["Time_s"].to_numpy(dtype=float)
+            T = df["Temperature_C"].to_numpy(dtype=float) + 273.15
+            x = df["DensidadePct"].to_numpy(dtype=float) / 100.0
+            if t.size < 2:
+                continue
+            dxdt = np.gradient(x, t)
+            mask = (dxdt > 0) & (x > 0) & (x < 1)
+            if not np.any(mask):
+                continue
+            xs.append(1.0 / T[mask])
+            ys.append(np.log(dxdt[mask] / (1 - x[mask])))
+
+        if not xs:
+            raise ValueError("No valid data for fitting")
+
+        X = np.concatenate(xs)
+        Y = np.concatenate(ys)
+        coeffs = np.polyfit(X, Y, deg=1)
+        slope, intercept = coeffs
+        Ea = -slope * R / 1000.0
+        A = float(np.exp(intercept))
+        return Ea, A
+
+    def simulate_synthetic(self, ea: float, a: float, time_array: np.ndarray) -> pd.DataFrame:
+        """Generate synthetic experiment data.
+
+        Parameters
+        ----------
+        ea : float
+            Activation energy in kJ/mol.
+        a : float
+            Pre-exponential factor (1/s).
+        time_array : np.ndarray
+            Time vector in seconds.
+
+        Returns
+        -------
+        pd.DataFrame
+            Columns ``Time_s``, ``Temperature_C`` and ``DensidadePct``.
+        """
+        T_c = 1000.0
+        k = a * np.exp(-(ea * 1000.0) / (R * (T_c + 273.15)))
+        dens = 1 - np.exp(-k * time_array)
+        return pd.DataFrame(
+            {
+                "Time_s": time_array,
+                "Temperature_C": np.full_like(time_array, T_c),
+                "DensidadePct": dens * 100.0,
+            }
+        )
+
+    def curve_master_analysis(self) -> pd.DataFrame:
+        """Return master curve analysis for stored experiments.
+
+        Uses :func:`~ogum.processing.calculate_log_theta` with the fitted
+        activation energy.
+
+        Returns
+        -------
+        pd.DataFrame
+            Concatenated ``logtheta`` results for all experiments.
+        """
+        ea, _ = self.fit(self.experiments)
+        frames = [calculate_log_theta(df, ea) for df in self.experiments]
+        return pd.concat(frames, ignore_index=True)
+
+__all__ = ["MaterialCalibrator"]

--- a/tests/test_material_calibrator.py
+++ b/tests/test_material_calibrator.py
@@ -1,0 +1,46 @@
+import numpy as np
+import pandas as pd
+
+from ogum.material_calibrator import MaterialCalibrator
+
+
+def test_basic_instantiation():
+    df = pd.DataFrame(
+        {
+            "Time_s": np.linspace(0, 1, 5),
+            "Temperature_C": np.full(5, 1000.0),
+            "DensidadePct": np.linspace(0, 50, 5),
+        }
+    )
+    calib = MaterialCalibrator(df)
+    assert len(calib.experiments) == 1
+
+
+def test_fit_returns_parameters_close():
+    t = np.linspace(0, 10, 50)
+    ea_true = 60.0
+    a_true = 2.0
+    calib_tmp = MaterialCalibrator(pd.DataFrame())
+    df = calib_tmp.simulate_synthetic(ea_true, a_true, t)
+    est_ea, est_a = MaterialCalibrator.fit(df)
+    assert np.isclose(est_ea, ea_true, rtol=0.3)
+    assert np.isclose(est_a, a_true, rtol=0.3)
+
+
+def test_simulate_synthetic_structure():
+    t = np.linspace(0, 5, 10)
+    calib_tmp = MaterialCalibrator(pd.DataFrame())
+    df = calib_tmp.simulate_synthetic(40.0, 1.0, t)
+    assert list(df.columns) == ["Time_s", "Temperature_C", "DensidadePct"]
+    assert df["DensidadePct"].between(0, 100).all()
+    assert (df["Temperature_C"] == df["Temperature_C"].iloc[0]).all()
+
+
+def test_curve_master_analysis_columns():
+    t = np.linspace(0, 2, 10)
+    calib_tmp = MaterialCalibrator(pd.DataFrame())
+    df = calib_tmp.simulate_synthetic(50.0, 1.0, t)
+    calib = MaterialCalibrator(df)
+    result = calib.curve_master_analysis()
+    assert list(result.columns) == ["logtheta", "valor", "tempo_s"]
+    assert len(result) == len(df)


### PR DESCRIPTION
## Summary
- implement `MaterialCalibrator` for curve fitting and master analysis
- expose `MaterialCalibrator` in package
- test calibration workflow

## Testing
- `ruff check ogum/material_calibrator.py tests/test_material_calibrator.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68712076ddb483279eadda07fa5a5cce