### PR TITLE
Refactor filters and plotting

### DIFF
--- a/ogum/__init__.py
+++ b/ogum/__init__.py
@@ -13,7 +13,8 @@ from .core import (
     generalized_logistic_stable,
     SOVSSolver,
 )
-from .utils import normalize_columns, orlandini_araujo_filter
+from .utils import normalize_columns, orlandini_araujo_filter, savgol_filter
+from .plotting import plot_sintering_curves
 from .processing import calculate_log_theta
 from .material_calibrator import MaterialCalibrator
 
@@ -31,6 +32,8 @@ __all__ = [
     "SOVSSolver",
     "normalize_columns",
     "orlandini_araujo_filter",
+    "savgol_filter",
     "calculate_log_theta",
     "MaterialCalibrator",
+    "plot_sintering_curves",
 ]

--- a/ogum/ogum64.py
+++ b/ogum/ogum64.py
@@ -50,7 +50,7 @@ from ogum.utils import (
 
 
 # Importa funções do SciPy para processamento dos dados, filtragem e ajuste de curvas (cruciais para sinterização)
-from scipy.signal import savgol_filter
+from ogum.utils import savgol_filter
 from scipy.interpolate import interp1d
 
 try:
@@ -589,7 +589,7 @@ import numpy as np
 import ipywidgets as widgets
 from IPython.display import display, clear_output
 import matplotlib.pyplot as plt
-from scipy.signal import savgol_filter
+from ogum.utils import savgol_filter
 from scipy.interpolate import interp1d
 
 
@@ -866,7 +866,9 @@ class Modulo3Recorte:
                         exibir_erro(f"Ensaio {idx + 1}: Poucos pontos p/ Savitzky-Golay.")
                         return
                     w = min(11, (len(dfi) // 2) * 2 + 1)
-                    dfi[dens_col] = savgol_filter(dfi[dens_col], w, 2)
+                    dfi[dens_col] = savgol_filter(
+                        dfi[[dens_col]], window=w, polyorder=2
+                    )[dens_col]
                     exibir_mensagem(f"Ensaio {idx + 1}: Savitzky-Golay aplicado (window={w}).")
                 elif method in ("linear", "cubic"):
                     # Atualize o drop_duplicates para usar a coluna de tempo dinamicamente

--- a/ogum/ogum72.py
+++ b/ogum/ogum72.py
@@ -36,7 +36,7 @@ import ipywidgets as widgets
 from IPython.display import display, HTML
 
 # Funções do SciPy
-from scipy.signal import savgol_filter
+from ogum.utils import savgol_filter
 from scipy.interpolate import interp1d
 from scipy.optimize import curve_fit, minimize_scalar
 from scipy.stats import linregress
@@ -436,7 +436,7 @@ import numpy as np
 import ipywidgets as widgets
 from IPython.display import display, clear_output, HTML
 import matplotlib.pyplot as plt
-from scipy.signal import savgol_filter
+from ogum.utils import savgol_filter
 from scipy.interpolate import interp1d, PchipInterpolator, Akima1DInterpolator
 import sys  # Importa a biblioteca sys
 
@@ -621,8 +621,7 @@ class Modulo3Recorte:
                 if w < 5:
                     raise ValueError("Pontos insuficientes para Savitzky-Golay.")
 
-                for col in df_filtered.select_dtypes(include=np.number).columns:
-                    df_filtered.loc[:, col] = savgol_filter(df_filtered[col].values, w, 2)
+                df_filtered = savgol_filter(df_filtered, window=w, polyorder=2)
                 exibir_mensagem(f"Filtro Savitzky-Golay aplicado (janela={w}).")
 
             elif method in ("linear", "cubic", "pchip", "akima"):
@@ -2694,7 +2693,7 @@ import ipywidgets as widgets
 from IPython.display import display, clear_output, HTML
 import numpy as np
 import pandas as pd
-from scipy.signal import savgol_filter
+from ogum.utils import savgol_filter
 from scipy.interpolate import interp1d
 
 # Importações de utilitários do Módulo 1

--- a/ogum/ogum80.py
+++ b/ogum/ogum80.py
@@ -37,7 +37,7 @@ from IPython.display import display, HTML
 from ogum.utils import orlandini_araujo_filter
 
 # Funções do SciPy
-from scipy.signal import savgol_filter
+from ogum.utils import savgol_filter
 from scipy.interpolate import interp1d
 from scipy.optimize import curve_fit, minimize_scalar
 from scipy.stats import linregress
@@ -424,7 +424,7 @@ import numpy as np
 import ipywidgets as widgets
 from IPython.display import display, clear_output, HTML
 import matplotlib.pyplot as plt
-from scipy.signal import savgol_filter
+from ogum.utils import savgol_filter
 from scipy.interpolate import interp1d, PchipInterpolator, Akima1DInterpolator
 
 
@@ -600,8 +600,7 @@ class Modulo3Recorte:
                     w = min(11, (len(dfi) // 2) * 2 + 1)  # Janela adaptativa e ímpar
                     if w < 5:
                         raise ValueError("Pontos insuficientes para Savitzky-Golay.")
-                    df_filtered[dens_col] = savgol_filter(df_filtered[dens_col], w, 2)
-                    df_filtered[temp_col] = savgol_filter(df_filtered[temp_col], w, 2)  # Suaviza temp também
+                    df_filtered = savgol_filter(df_filtered, window=w, polyorder=2)
                     exibir_mensagem(f"Filtro Savitzky-Golay aplicado (janela={w}).")
 
                 elif method in ("linear", "cubic", "pchip", "akima"):
@@ -2686,7 +2685,7 @@ import ipywidgets as widgets
 from IPython.display import display, clear_output
 import numpy as np
 import pandas as pd
-from scipy.signal import savgol_filter
+from ogum.utils import savgol_filter
 from scipy.interpolate import interp1d
 
 # Importações de utilidades

--- a/ogum/plotting.py
+++ b/ogum/plotting.py
@@ -1,0 +1,58 @@
+import matplotlib.pyplot as plt
+import pandas as pd
+from typing import Optional, Sequence, Tuple
+
+
+def plot_sintering_curves(
+    df_ensaio: pd.DataFrame, ax: Optional[plt.Axes] = None
+) -> Tuple[plt.Figure, Sequence[plt.Axes]]:
+    """Plot standard sintering curves for ``df_ensaio``.
+
+    Parameters
+    ----------
+    df_ensaio : pd.DataFrame
+        Data containing columns starting with ``Time_s``, ``Temperature_C``
+        and ``DensidadePct``.
+    ax : matplotlib.axes.Axes, optional
+        Axis to draw the first subplot on. When ``None`` a new figure is
+        created.
+    Returns
+    -------
+    (figure, axes)
+        The created figure and list of axes.
+    """
+    time_col = next((c for c in df_ensaio.columns if c.startswith("Time_s")), None)
+    temp_col = next(
+        (c for c in df_ensaio.columns if c.startswith("Temperature_C")), None
+    )
+    dens_col = next(
+        (c for c in df_ensaio.columns if c.startswith("DensidadePct")), None
+    )
+    if not (time_col and temp_col and dens_col):
+        raise ValueError("Required columns missing")
+
+    if ax is None:
+        fig, axs = plt.subplots(1, 3, figsize=(15, 4), tight_layout=True)
+    else:
+        fig = ax.figure
+        axs = [ax, fig.add_subplot(1, 3, 2), fig.add_subplot(1, 3, 3)]
+        fig.set_size_inches(15, 4)
+
+    fig.suptitle("Sintering Curves")
+
+    axs[0].plot(df_ensaio[time_col], df_ensaio[dens_col], ".-")
+    axs[0].set(xlabel="Tempo (s)", ylabel="Densidade (%)")
+
+    axs[1].plot(df_ensaio[temp_col], df_ensaio[dens_col], "r.-")
+    axs[1].set(xlabel="Temperatura (°C)", ylabel="Densidade (%)")
+
+    axs[2].plot(df_ensaio[time_col], df_ensaio[temp_col], "g.-")
+    axs[2].set(xlabel="Tempo (s)", ylabel="Temperatura (°C)")
+
+    for a in axs:
+        a.grid(True, alpha=0.5)
+
+    return fig, axs
+
+
+__all__ = ["plot_sintering_curves"]

--- a/ogum/utils.py
+++ b/ogum/utils.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
-from typing import Dict, Iterable
+from typing import Dict, Iterable, Optional
 
 import pandas as pd
+from scipy.signal import savgol_filter as _savgol_filter
 
 
-def normalize_columns(df: pd.DataFrame, mapping: Dict[str, Iterable[str]]) -> pd.DataFrame:
+def normalize_columns(
+    df: pd.DataFrame, mapping: Dict[str, Iterable[str]]
+) -> pd.DataFrame:
     """Return ``df`` with columns renamed according to ``mapping``.
 
     The ``mapping`` keys correspond to the desired column names.  Each value is
@@ -21,7 +24,9 @@ def normalize_columns(df: pd.DataFrame, mapping: Dict[str, Iterable[str]]) -> pd
         for alias in [new_col, *aliases]:
             alias_map[alias.lower()] = new_col
 
-    renames = {col: alias_map[col.lower()] for col in df.columns if col.lower() in alias_map}
+    renames = {
+        col: alias_map[col.lower()] for col in df.columns if col.lower() in alias_map
+    }
     return df.rename(columns=renames)
 
 
@@ -45,4 +50,34 @@ def orlandini_araujo_filter(df: pd.DataFrame, bin_size: int = 10) -> pd.DataFram
     return grouped.reset_index(drop=True)
 
 
-__all__ = ["normalize_columns", "orlandini_araujo_filter"]
+def savgol_filter(
+    df: pd.DataFrame,
+    window: Optional[int] = None,
+    polyorder: int = 2,
+) -> pd.DataFrame:
+    """Apply a Savitzky–Golay filter to numeric columns of ``df``.
+
+    The window size is chosen adaptively when ``window`` is ``None`` using
+    ``min(11, (len(df) // 2) * 2 + 1)``. Non-numeric columns are preserved.
+    """
+
+    if df.empty:
+        return df.copy()
+
+    if window is None:
+        window = min(11, max(3, (len(df) // 2) * 2 + 1))
+    if window % 2 == 0:
+        window += 1
+
+    df_filtered = df.copy()
+    for col in df_filtered.select_dtypes(include="number").columns:
+        if len(df_filtered[col]) < polyorder + 1:
+            continue
+        df_filtered[col] = _savgol_filter(
+            df_filtered[col].to_numpy(), window, polyorder
+        )
+
+    return df_filtered
+
+
+__all__ = ["normalize_columns", "orlandini_araujo_filter", "savgol_filter"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import pytest
+from scipy.signal import savgol_filter as scipy_savgol
 
 from ogum import utils
 
@@ -34,3 +35,15 @@ def test_orlandini_missing_columns():
     df = pd.DataFrame({"Time_s": [0], "Temperature_C": [100]})
     with pytest.raises(ValueError):
         utils.orlandini_araujo_filter(df)
+
+
+def test_savgol_filter_basic():
+    df = pd.DataFrame({"A": [1, 2, 3, 4, 5], "B": [10, 11, 12, 13, 14]})
+    result = utils.savgol_filter(df, window=5, polyorder=2)
+    expected = pd.DataFrame(
+        {
+            "A": scipy_savgol(df["A"].to_numpy(), 5, 2),
+            "B": scipy_savgol(df["B"].to_numpy(), 5, 2),
+        }
+    )
+    pd.testing.assert_frame_equal(result, expected)


### PR DESCRIPTION
## Summary
- expose new reusable `savgol_filter` helper
- add plotting utilities module with `plot_sintering_curves`
- re-export helpers in `ogum.__init__`
- adjust legacy modules to use new helper
- test the new filter

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6871279873288327943529644ba15450