### PR TITLE
Add bootstrap stats module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install ruff scikit-learn
+          pip install ruff scikit-learn matplotlib scipy
 
       - name: Install optional FEM dependencies
         run: |

--- a/ogum/__init__.py
+++ b/ogum/__init__.py
@@ -17,6 +17,7 @@ from .utils import normalize_columns, orlandini_araujo_filter, savgol_filter
 from .plotting import plot_sintering_curves
 from .processing import calculate_log_theta
 from .material_calibrator import MaterialCalibrator
+from .stats import bootstrap_ea, shapiro_residuals, generate_report
 
 __all__ = [
     "R",
@@ -36,4 +37,7 @@ __all__ = [
     "calculate_log_theta",
     "MaterialCalibrator",
     "plot_sintering_curves",
+    "bootstrap_ea",
+    "shapiro_residuals",
+    "generate_report",
 ]

--- a/ogum/stats.py
+++ b/ogum/stats.py
@@ -1,0 +1,122 @@
+"""Statistical utilities for kinetic analysis."""
+
+from __future__ import annotations
+
+from typing import List, Tuple, Literal
+
+import base64
+import io
+
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+from scipy.stats import shapiro
+
+from .material_calibrator import MaterialCalibrator
+
+
+def bootstrap_ea(
+    experiments: List[pd.DataFrame], n_bootstrap: int = 1000
+) -> Tuple[float, float]:
+    """Estimate 95% confidence interval for activation energy using bootstrapping.
+
+    Parameters
+    ----------
+    experiments : list of pandas.DataFrame
+        Each DataFrame must contain ``Time_s``, ``Temperature_C`` and
+        ``DensidadePct`` columns.
+    n_bootstrap : int, default=1000
+        Number of bootstrap replicates.
+
+    Returns:
+    -------
+    tuple of float
+        Lower and upper bounds of the 95% confidence interval for ``Ea``
+        in kJ/mol.
+    """
+    if not experiments:
+        raise ValueError("No experiments provided")
+
+    rng = np.random.default_rng()
+    eas = np.empty(n_bootstrap, dtype=float)
+    n = len(experiments)
+    for i in range(n_bootstrap):
+        idx = rng.integers(0, n, n)
+        sample = [experiments[j] for j in idx]
+        ea, _ = MaterialCalibrator.fit(sample)
+        eas[i] = ea
+
+    ci_low, ci_high = np.percentile(eas, [2.5, 97.5])
+    return float(ci_low), float(ci_high)
+
+
+def shapiro_residuals(fit_results: pd.DataFrame) -> float:
+    """Return Shapiro–Wilk p-value for residual normality.
+
+    Parameters
+    ----------
+    fit_results : pandas.DataFrame
+        DataFrame containing a ``residual`` column.
+
+    Returns:
+    -------
+    float
+        P-value of the Shapiro–Wilk test.
+    """
+    if "residual" not in fit_results:
+        raise ValueError("DataFrame must contain 'residual' column")
+
+    _, p_value = shapiro(fit_results["residual"].to_numpy(dtype=float))
+    return float(p_value)
+
+
+def generate_report(results: dict, output: Literal["md", "html"] = "md") -> str:
+    """Generate a Markdown or HTML statistical report.
+
+    Parameters
+    ----------
+    results : dict
+        Dictionary with keys ``ea_bootstrap`` (tuple of floats), ``shapiro_p``
+        (float) and ``residuals`` (array-like of bootstrap Ea values).
+    output : {{'md', 'html'}}, default 'md'
+        Format of the generated report.
+
+    Returns:
+    -------
+    str
+        Rendered report.
+    """
+    ci_low, ci_high = results["ea_bootstrap"]
+    shapiro_p = results["shapiro_p"]
+    values = np.asarray(results.get("residuals", []), dtype=float)
+
+    fig, ax = plt.subplots()
+    ax.hist(values, bins=20, color="C0", edgecolor="black")
+    ax.set_title("Bootstrap Ea")
+    ax.set_xlabel("Ea (kJ/mol)")
+    ax.set_ylabel("Frequency")
+    fig.tight_layout()
+
+    buffer = io.BytesIO()
+    fig.savefig(buffer, format="png")
+    plt.close(fig)
+    b64 = base64.b64encode(buffer.getvalue()).decode()
+
+    if output == "html":
+        image = f'<img src="data:image/png;base64,{b64}" />'
+        report = (
+            "<h2>Relat\u00f3rio Estat\u00edstico</h2>"
+            f"<p><b>Intervalo Ea 95%:</b> {ci_low:.2f} – {ci_high:.2f} kJ/mol</p>"
+            f"<p><b>p-valor Shapiro:</b> {shapiro_p:.3f}</p>" + image
+        )
+    else:
+        image = f"![bootstrap](data:image/png;base64,{b64})"
+        report = (
+            "## Relat\u00f3rio Estat\u00edstico\n\n"
+            f"* Intervalo Ea 95%: {ci_low:.2f} – {ci_high:.2f} kJ/mol\n"
+            f"* p-valor Shapiro: {shapiro_p:.3f}\n\n" + image + "\n"
+        )
+    return report
+
+
+__all__ = ["bootstrap_ea", "shapiro_residuals", "generate_report"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ scipy
 pandas
 openpyxl
 scikit-learn
+matplotlib
 
 # FEM and Visualization
 fenics-dolfinx

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,41 @@
+import numpy as np
+import pandas as pd
+
+from ogum.stats import bootstrap_ea, shapiro_residuals, generate_report
+from ogum.material_calibrator import MaterialCalibrator
+
+
+def test_bootstrap_ea_contains_true():
+    rng = np.random.default_rng(0)
+    t = np.linspace(0, 5, 20)
+    ea_true = 60.0
+    a_true = 2.0
+    calib = MaterialCalibrator(pd.DataFrame())
+    experiments = []
+    for _ in range(3):
+        df = calib.simulate_synthetic(ea_true, a_true, t)
+        df["DensidadePct"] += rng.normal(scale=0.5, size=len(t))
+        experiments.append(df)
+
+    ci_low, ci_high = bootstrap_ea(experiments, n_bootstrap=200)
+    assert ci_low <= ea_true <= ci_high
+
+
+def test_shapiro_residuals_normal():
+    rng = np.random.default_rng(1)
+    df = pd.DataFrame({"residual": rng.normal(size=50)})
+    p_val = shapiro_residuals(df)
+    assert p_val >= 0.05
+
+
+def test_generate_report_contents():
+    vals = np.linspace(50, 70, 10)
+    res = {
+        "ea_bootstrap": (50.0, 70.0),
+        "shapiro_p": 0.12,
+        "residuals": vals,
+    }
+    text = generate_report(res, output="md")
+    assert "Intervalo Ea" in text
+    assert "p-valor Shapiro" in text
+    assert "data:image/png;base64" in text


### PR DESCRIPTION
## Summary
- implement `ogum.stats` with bootstrap analysis, Shapiro test and reporting utilities
- expose stats functions in package init
- provide tests for new module
- add matplotlib to requirements and install it in CI

## Testing
- `ruff format --check ogum/stats.py tests/test_stats.py`
- `ruff check ogum/stats.py tests/test_stats.py`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6871323841348327904064bfb6e29921