### PR TITLE
Integrate statistical report module

### DIFF
--- a/ogum/__init__.py
+++ b/ogum/__init__.py
@@ -18,6 +18,7 @@ from .plotting import plot_sintering_curves
 from .processing import calculate_log_theta
 from .material_calibrator import MaterialCalibrator
 from .stats import bootstrap_ea, shapiro_residuals, generate_report
+from .final_report import FinalReportModule
 
 __all__ = [
     "R",
@@ -40,4 +41,5 @@ __all__ = [
     "bootstrap_ea",
     "shapiro_residuals",
     "generate_report",
+    "FinalReportModule",
 ]

--- a/ogum/final_report.py
+++ b/ogum/final_report.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import List
+
+import ipywidgets as widgets
+from IPython.display import clear_output
+
+from .core import SinteringDataRecord
+
+
+class FinalReportModule:
+    """UI module to generate statistical HTML reports."""
+
+    def __init__(self, sintering_records: List[SinteringDataRecord]):
+        self.sintering_records = list(sintering_records)
+        self._build_ui()
+
+    def _build_ui(self) -> None:
+        self.btn_generate = widgets.Button(
+            description="Gerar Relatório Estatístico", button_style="info"
+        )
+        self.btn_generate.on_click(self._on_generate_report)
+        self.out = widgets.Output()
+        self.report_html = widgets.HTML()
+        self.main_ui = widgets.VBox([
+            self.btn_generate,
+            self.out,
+            self.report_html,
+        ])
+
+    def _on_generate_report(self, _=None) -> None:
+        with self.out:
+            clear_output()
+            try:
+                from .stats import bootstrap_ea, shapiro_residuals, generate_report
+                import pandas as pd
+
+                experiments = [
+                    rec.df
+                    for rec in self.sintering_records
+                    if {"Time_s", "Temperature_C", "DensidadePct"}.issubset(rec.df.columns)
+                ]
+                if not experiments:
+                    raise ValueError(
+                        "Nenhum dataset válido encontrado (Time_s, Temperature_C, DensidadePct)."
+                    )
+
+                ci_low, ci_high = bootstrap_ea(experiments)
+
+                resid_df = None
+                for rec in self.sintering_records:
+                    if "residual" in rec.df.columns:
+                        resid_df = rec.df[["residual"]]
+                        break
+
+                p_val = shapiro_residuals(resid_df) if resid_df is not None else 0.0
+                results = {
+                    "ea_bootstrap": (ci_low, ci_high),
+                    "shapiro_p": p_val,
+                    "residuals": resid_df["residual"] if resid_df is not None else [],
+                }
+                html = generate_report(results, output="html")
+                self.report_html.value = html
+            except Exception as exc:  # pragma: no cover - visual feedback only
+                self.report_html.value = f"<b>Erro ao gerar relat\u00f3rio: {exc}</b>"

--- a/ogum/ogum80.py
+++ b/ogum/ogum80.py
@@ -3001,6 +3001,7 @@ from modulo5_4_roteador import Modulo5_4_Roteador
 from modulo5_5_refinamento import Modulo5_5_Refinamento
 from modulo6_0_arrhenius import Modulo6_0_Arrhenius
 from modulo6_1_arrhenius_display import Modulo6_1ArrheniusDisplay
+from .final_report import FinalReportModule
 
 # Utilitários de interface do seu arquivo core
 # from .core import exibir_mensagem, exibir_erro
@@ -3035,9 +3036,18 @@ class MainInteractive:
             "REVIEW",
             "FINAL_ANALYSIS",
             "REFINEMENT",
+            "STATISTICAL_REPORT",
         ]
 
-        self.arrhenius_sequence = ["INTRO", "IMPORT", "FILTER", "METHOD_CHOICE", "ARRHENIUS_CALC", "ARRHENIUS_DISPLAY"]
+        self.arrhenius_sequence = [
+            "INTRO",
+            "IMPORT",
+            "FILTER",
+            "METHOD_CHOICE",
+            "ARRHENIUS_CALC",
+            "ARRHENIUS_DISPLAY",
+            "STATISTICAL_REPORT",
+        ]
 
         # Widgets da UI
         self._build_ui()
@@ -3125,6 +3135,7 @@ class MainInteractive:
             "REVIEW": self._run_fit_and_show_review,
             "FINAL_ANALYSIS": self._show_final_analysis_router,
             "REFINEMENT": self.show_refinement_module,
+            "STATISTICAL_REPORT": self._show_statistical_report,
         }
 
         # Executa a função correspondente ao passo
@@ -3279,6 +3290,12 @@ class MainInteractive:
             parent=self,
         )
         self.modules_container.children = (self.modules["refinement"].main_ui,)
+        self._update_nav_buttons()
+
+    def _show_statistical_report(self):
+        self.step_label.value = "<h3>Passo 12: Relatório Estatístico</h3>"
+        self.modules["final_report"] = FinalReportModule(self.sintering_records)
+        self.modules_container.children = (self.modules["final_report"].main_ui,)
         self._update_nav_buttons()
 
     def trigger_refit(self, p0_overrides):

--- a/tests/test_final_report.py
+++ b/tests/test_final_report.py
@@ -1,0 +1,22 @@
+import pandas as pd
+
+from ogum import SinteringDataRecord, FinalReportModule
+
+
+def _make_record():
+    df = pd.DataFrame({
+        "Time_s": [0, 1, 2, 3, 4],
+        "Temperature_C": [300, 320, 340, 360, 380],
+        "DensidadePct": [10, 20, 40, 60, 80],
+    })
+    return SinteringDataRecord(ensaio_id=0, Ea=50.0, tipo_dado_y="densidade_original", df=df)
+
+
+def test_final_report_instantiates():
+    mod = FinalReportModule([_make_record()])
+    assert isinstance(mod, FinalReportModule)
+
+
+def test_generate_report_runs():
+    mod = FinalReportModule([_make_record()])
+    mod._on_generate_report(None)


### PR DESCRIPTION
## Summary
- create new `FinalReportModule` for statistical reporting using bootstrap and Shapiro tests
- expose `FinalReportModule` from `ogum.__init__`
- integrate report step in `MainInteractive` workflow
- add unit tests for the new module

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68713e0a6bdc8327b9c06ecce2b792a1