### PR TITLE
Fix CI dev dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           # Instala as dependências de produção e desenvolvimento
           pip install -r requirements.txt
           # É uma boa prática ter um requirements-dev.txt, mas por agora instalamos manualmente
-          pip install pytest pytest-cov ruff matplotlib scipy
+          pip install pytest pytest-cov ruff
 
       - name: Install local package 'ogum'
         run: pip install -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,5 @@ pytest
 pytest-cov
 codecov
 
+ruff
+


### PR DESCRIPTION
## Summary
- add `ruff` to requirements
- simplify dev installs in CI

## Testing
- `ruff check .` *(fails: Missing docstrings etc.)*
- `pytest -q` *(fails: ModuleNotFoundError: httpx, pandas, numpy)*
- `pytest --cov=ogum --cov-report=xml` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68714c04ab988327876244e8ced39fbc