### PR TITLE
REF-012: add FastAPI REST endpoints and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,9 @@ jobs:
           ruff format --check .
 
       - name: Run tests with coverage
-        run: pytest --cov=ogum --cov-report=xml
+        run: |
+          pytest --cov=ogum --cov-report=xml
+          pytest tests/test_api.py --maxfail=1 --disable-warnings
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,10 @@ COPY requirements.txt .
 RUN python -m pip install --upgrade pip \
     && pip install -r requirements.txt \
     && pip install voila pytest-cov ruff scipy scikit-learn pyvista
+RUN pip install fastapi uvicorn[standard] pydantic
 
 COPY . .
 
 EXPOSE 8866
 ENTRYPOINT ["voila", "--no-browser", "--Voila.ip=0.0.0.0", "notebooks/FEM_example.ipynb"]
+CMD ["uvicorn", "ogum.api:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/ogum/api.py
+++ b/ogum/api.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+# ruff: noqa: D100, E402
+"""FastAPI endpoints exposing core Ogum functionality."""
+from fastapi import FastAPI
+from pydantic import BaseModel
+import pandas as pd
+
+from ogum.cms import calc_cms
+from ogum.fem_interface import create_unit_mesh, densify_mesh
+
+app = FastAPI(title="Ogum Sintering API")
+
+
+class MasterInput(BaseModel):
+    """Input data for the master curve calculation."""
+
+    time_s: list[float]
+    temperature_c: list[float]
+    density_pct: list[float]
+    energia_ativacao_kj: float
+
+
+class FEMInput(BaseModel):
+    """Input parameters for the FEM densification solver."""
+
+    mesh_size: float
+    history: list[tuple[float, float]]
+
+
+@app.post("/calc-master")
+def calc_master(input: MasterInput) -> dict[str, list[float]]:
+    """Return master curve arrays from experimental data."""
+    df = pd.DataFrame(
+        {
+            "Time_s": input.time_s,
+            "Temperature_C": input.temperature_c,
+            "DensidadePct": input.density_pct,
+        }
+    )
+    df_out = calc_cms(df, energia_ativacao_kj=input.energia_ativacao_kj)
+    return {
+        "logtheta": df_out["logtheta"].tolist(),
+        "valor": df_out["valor"].tolist(),
+        "tempo_s": df_out["tempo_s"].tolist(),
+    }
+
+
+@app.post("/fem-sim")
+def fem_sim(input: FEMInput) -> dict[str, list[float]]:
+    """Simulate densification across a mesh using ``SOVSSolver``."""
+    mesh = create_unit_mesh(input.mesh_size)
+    densities = densify_mesh(mesh, input.history)
+    return {"densities": densities.tolist()}
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    """Simple health check endpoint."""
+    return {"status": "ok"}

--- a/ogum/cms.py
+++ b/ogum/cms.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+# ruff: noqa: D100, E402
+"""Utilities for master curve calculations."""
+
+import pandas as pd
+
+from .processing import calculate_log_theta
+
+
+def calc_cms(df: pd.DataFrame, energia_ativacao_kj: float) -> pd.DataFrame:
+    """Wrapper for :func:`calculate_log_theta` returning master curve columns."""
+    return calculate_log_theta(df, energia_ativacao_kj)
+
+
+__all__ = ["calc_cms"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ pyvista
 # Web API
 fastapi
 uvicorn[standard]
+pydantic
 httpx
 
 # Web UI


### PR DESCRIPTION
## Summary
- create simple master curve function in `ogum.cms`
- expose master curve and FEM densification helpers via FastAPI in `ogum.api`
- test new endpoints with `httpx.AsyncClient`
- install fastapi stack in Docker image
- run API tests in CI workflow

## Testing
- `ruff check .`
- `ruff format ogum/api.py ogum/cms.py tests/test_api.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68715ffa01a08327b2caac820661f970