### PR TITLE
Generalized Docker setup and compose services

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,3 @@ RUN pip install fastapi uvicorn[standard] pydantic
 COPY . .
 
 EXPOSE 8866
-ENTRYPOINT ["voila", "--no-browser", "--Voila.ip=0.0.0.0", "notebooks/FEM_example.ipynb"]
-CMD ["uvicorn", "ogum.api:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ Acesse a versão hospedada do Ogum Software no Cloud Run [aqui](URL_DO_SEU_CLOUD
 ```bash
 docker-compose up --build
 ```
-Acesse http://localhost:8866 para ver o notebook FEM_example.ipynb rodando via Voila.
+Isso inicia dois serviços:
+- Voila em [http://localhost:8866](http://localhost:8866)
+- API em [http://localhost:8000](http://localhost:8000) com docs em [http://localhost:8000/docs](http://localhost:8000/docs)
 
 ## Estrutura do código
 O diretório `ogum/` reúne os módulos Python gerados a partir dos notebooks em

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,13 @@
 version: "3.8"
 services:
-  ogum-voila:
+  voila_app:
     build: .
+    command: voila --no-browser --Voila.ip=0.0.0.0 notebooks/FEM_example.ipynb
     ports:
       - "8866:8866"
-    volumes:
-      - .:/app
+
+  api_service:
+    build: .
+    command: uvicorn ogum.api:app --host 0.0.0.0 --port 8000
+    ports:
+      - "8000:8000"


### PR DESCRIPTION
## Summary
- remove default entrypoint and command from Dockerfile
- define separate Voila and FastAPI services in docker-compose
- update README instructions for running both services

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68716223884c8327ba7cf6fee64d0795