### PR TITLE
fix: align dependencies, CI, Dockerfile, and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,8 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          # Instala dependências de produção e desenvolvimento
-          # É uma boa prática ter um requirements-dev.txt, mas por agora instalamos tudo
           pip install -r requirements.txt
-          pip install pytest pytest-cov ruff matplotlib scipy httpx
+          pip install -r requirements-dev.txt
 
       - name: Install local package 'ogum'
         run: pip install -e .

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.11-slim
 
 WORKDIR /app
 COPY requirements.txt .
+RUN apt-get update && apt-get install -y gmsh
 RUN python -m pip install --upgrade pip \
     && pip install -r requirements.txt \
     && pip install voila pytest-cov ruff scipy scikit-learn pyvista
@@ -10,3 +11,4 @@ RUN pip install fastapi uvicorn[standard] pydantic
 COPY . .
 
 EXPOSE 8866
+EXPOSE 8000

--- a/README.md
+++ b/README.md
@@ -7,7 +7,13 @@ Este repositório contém quatro experimentos (64, 72, 80 e FZEA) em formato
 Jupyter (`notebooks/`) e seus correspondentes módulos Python (`ogum/`).
 
 ## 🚀 Acesso Online
-Acesse a versão online do Ogum Software [aqui](URL_DO_SEU_CLOUD_RUN).
+Após cada `push` para o branch `main`, a aplicação é automaticamente publicada no Google Cloud Run. Para aceder:
+
+1.  Vá para a secção **"Actions"** do repositório no GitHub.
+2.  Encontre o último workflow de **"Deploy"** que foi executado com sucesso.
+3.  Dentro dos logs do job `deploy-to-cloud-run`, irá encontrar a URL do serviço, que se parecerá com: `https://ogumsoftware-xxxxxxxx-uc.a.run.app`.
+
+Pode também gerir os seus serviços diretamente no [Google Cloud Run Console](https://console.cloud.google.com/run).
 
 ## Instalação rápida
 ```bash
@@ -18,11 +24,8 @@ pytest -q
 Alguns testes de FEM e da API exigem dependências extras:
 
 ```bash
-pip install fenicsx-dolfinx fastapi httpx
+pip install fenics-dolfinx fastapi httpx
 ```
-
-## 🚀 Acesso Online
-Acesse a versão hospedada do Ogum Software no Cloud Run [aqui](URL_DO_SEU_CLOUD_RUN).
 
 ## 🚢 Deploy com Docker & Voila
 

--- a/ogum/utils.py
+++ b/ogum/utils.py
@@ -60,7 +60,6 @@ def savgol_filter(
     The window size is chosen adaptively when ``window`` is ``None`` using
     ``min(11, (len(df) // 2) * 2 + 1)``. Non-numeric columns are preserved.
     """
-
     if df.empty:
         return df.copy()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,6 @@ exclude = [
     "IPython/*",
     "notebooks/*",
     "*.ipynb",
-    "ogum/core.py",
-    "ogum/utils.py",
     "tests/conftest.py",
 ]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+pytest
+pytest-cov
+ruff
+httpx

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,9 @@ matplotlib
 fenics-dolfinx
 pyvista
 
+# Mesh generation
+gmsh
+
 # Web API
 fastapi
 uvicorn[standard]


### PR DESCRIPTION
## Summary
- align installation docs with requirements
- add gmsh as dependency
- add development requirements file
- simplify CI dependency install
- expose API port in Dockerfile and install gmsh
- run ruff on all files

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68730e65c71c8327a289647311e33f5b