### PR TITLE
Fix Docker build by using dolfinx base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,24 @@
-FROM python:3.11-slim
+# 1. Usar a imagem oficial do FEniCS, que ja inclui dolfinx, gmsh e todas as suas dependencias de sistema.
+FROM dolfinx/dolfinx:v0.8.0
 
-# Instala dependências do sistema, incluindo gmsh
-RUN apt-get update && apt-get install -y gmsh && rm -rf /var/lib/apt/lists/*
-
-# Define o diretório de trabalho
+# 2. Definir o diretorio de trabalho dentro do container.
 WORKDIR /app
 
-# Copia apenas os ficheiros de requisitos primeiro para aproveitar o cache do Docker
+# 3. Copiar os ficheiros de requisitos para aproveitar o cache do Docker.
 COPY requirements.txt requirements-dev.txt ./
 
-# Instala as dependências Python
-RUN python -m pip install --upgrade pip \
-    && pip install -r requirements.txt \
-    && pip install -r requirements-dev.txt
+# 4. Instalar as nossas dependencias Python (o dolfinx JA ESTA na imagem).
+#    Usamos python3, que e o comando padrao nesta imagem.
+RUN python3 -m pip install --no-cache-dir --upgrade pip \
+    && python3 -m pip install --no-cache-dir -r requirements.txt \
+    && python3 -m pip install --no-cache-dir -r requirements-dev.txt
 
-# Copia o resto da aplicação
+# 5. Copiar o codigo da nossa aplicacao para o container.
 COPY . .
 
-# Instala o pacote local 'ogum'
-RUN pip install -e .
+# 6. Instalar o nosso pacote 'ogum' localmente para que possa ser importado.
+RUN python3 -m pip install --no-cache-dir -e .
 
-# Expõe as portas para a aplicação e para a API
+# 7. Expor as portas para a aplicacao Voila e para a API.
 EXPOSE 8866
 EXPOSE 8000

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ scikit-learn
 matplotlib
 
 # FEM and Visualization
-dolfinx
 pyvista
 
 # Mesh generation


### PR DESCRIPTION
## Summary
- remove dolfinx from requirements since it comes with the base image
- replace the Dockerfile to use the official dolfinx image

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687318e822a88327a9ef514ad7f1ba5d