### PR TITLE
Fix package discovery error by adding project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,26 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ogum_sintering_suite"
+version = "0.1.0"
+authors = [
+  { name="Huyrá Araujo", email="huyraestevao@ifsp.edu.br" },
+]
+description = "A suite for analyzing sintering processes."
+readme = "README.md"
+requires-python = ">=3.10"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["ogum*"]
+
 [tool.ruff]
 line-length = 88
 exclude = [


### PR DESCRIPTION
## Summary
- define build backend and project metadata in `pyproject.toml`
- specify package discovery so `pip install -e .` works

## Testing
- `pytest --maxfail=1 -q`


------
https://chatgpt.com/codex/tasks/task_e_68731bed01248327aa84e29f763ee9cb