### PR TITLE
Set up FEniCSx via conda in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,29 +20,45 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Configure Conda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: 3.11
+          environment-file: environment.yml
+          activate-environment: ci
+
+      - name: Show installed packages
+        run: conda list
+        shell: bash -l {0}
+
       - name: Install Dependencies
         run: |
+          conda activate ci
           sudo apt-get update && sudo apt-get install -y libglu1-mesa
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -e .[dev]
-
-      - name: Install optional FEM dependencies
-        run: |
-          python -m pip install fenics-dolfinx mpi4py
-
+        shell: bash -l {0}
       - name: Install local package 'ogum'
-        run: pip install -e .
+        run: |
+          conda activate ci
+          pip install -e .
+        shell: bash -l {0}
 
       - name: Lint and Format Check
         run: |
+          conda activate ci
           ruff check .
           ruff format --check .
+        shell: bash -l {0}
 
       - name: Run tests with coverage
         run: |
+          conda activate ci
           pytest --cov=ogum --cov-report=xml
           pytest tests/test_api.py --maxfail=1 --disable-warnings
+        shell: bash -l {0}
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,20 @@
+name: ci
+channels:
+  - conda-forge
+dependencies:
+  - python=3.11
+  - dolfinx        # FEniCSx
+  - mpi4py
+  - gmsh
+  - pytest
+  - pytest-asyncio
+  - numpy
+  - scipy
+  - pandas
+  - pytest-cov
+  - anyio
+  - uvicorn
+  - fastapi
+  - streamlit
+  - codecov
+  - ruff


### PR DESCRIPTION
## Summary
- add `environment.yml` for conda dependencies
- update CI workflow to configure conda and activate the `ci` env
- run tests and lint steps inside the conda environment

## Testing
- `ruff .` *(fails: unrecognized subcommand)*


------
https://chatgpt.com/codex/tasks/task_e_68733071e444832799eba6ef03f1d944