### PR TITLE
Fix FEM dependency installation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,8 @@ jobs:
 
       - name: Install optional FEM dependencies
         run: |
-          python -m pip install fenics-dolfinx mpi4py
+          sudo apt-get update
+          sudo apt-get install -y fenicsx
 
       - name: Install local package 'ogum'
         run: pip install -e .


### PR DESCRIPTION
## Summary
- install `fenicsx` via `apt-get` instead of using `pip` in CI workflow

## Testing
- `pytest -q` *(fails: ImportError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6873308cfbbc83278d8f1ae1904efb32