### PR TITLE
Replace mktemp with NamedTemporaryFile

### DIFF
--- a/src/ogum/mesh_generator.py
+++ b/src/ogum/mesh_generator.py
@@ -57,7 +57,8 @@ def generate_mesh(
     )
     gmsh.model.occ.synchronize()
     gmsh.model.mesh.generate(3)
-    msh_file = tempfile.mktemp(suffix=".msh")
+    with tempfile.NamedTemporaryFile(suffix=".msh", delete=False) as tmp:
+        msh_file = tmp.name
     gmsh.write(msh_file)
     gmsh.finalize()
     return msh_file

--- a/tests/test_mesh_generator.py
+++ b/tests/test_mesh_generator.py
@@ -16,3 +16,4 @@ def test_generate_mesh_runs_or_errors(tmp_path):
         path = generate_mesh(0.2, 1.0, 0.1, 1)
         assert os.path.isfile(path)
         assert path.endswith(".msh")
+        os.remove(path)


### PR DESCRIPTION
## Summary
- avoid using deprecated `mktemp` by switching to `NamedTemporaryFile`
- clean up the generated mesh file in the mesh test

## Testing
- `pytest -q` *(fails: async plugin missing, mpi4py missing)*

------
https://chatgpt.com/codex/tasks/task_e_68733d361f048327ababb7d810e6627d