### PR TITLE
Fix CI miniconda version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Miniconda
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v2
         with:
           environment-file: environment.yml
           activate-environment: ogum


### PR DESCRIPTION
## Summary
- point the `setup-miniconda` action to `v2`

## Testing
- `pytest -q` *(fails: No module named 'numpy', 'pandas', 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68734d82400c8327851229305b5ca447