### PR TITLE
Update Miniconda action version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Miniconda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v1
         with:
           environment-file: environment.yml
           activate-environment: ogum


### PR DESCRIPTION
## Summary
- use setup-miniconda v1 in CI workflow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687350be22a48327a89178ee4243a565