### PR TITLE
Finish generate_mesh implementation

### DIFF
--- a/src/ogum/mesh_generator.py
+++ b/src/ogum/mesh_generator.py
@@ -50,7 +50,18 @@ def generate_mesh(
             tag = gmsh.model.occ.addSphere(x, y, z, radius)
             sphere_tags.append(tag)
 
-
-
+        gmsh.model.occ.cut(
+            [(3, 1)],
+            [(3, t) for t in sphere_tags],
+            removeObject=False,
+            removeTool=True,
+        )
+        gmsh.model.occ.synchronize()
+        gmsh.model.mesh.generate(3)
+        msh_file = tempfile.mktemp(suffix=".msh")
+        gmsh.write(msh_file)
+        return msh_file
+    finally:
+        gmsh.finalize()
 
 __all__ = ["generate_mesh"]


### PR DESCRIPTION
## Summary
- implement missing gmsh operations in `generate_mesh`
- ensure gmsh finalizes in a `finally` block

## Testing
- `python -m compileall src/ogum/mesh_generator.py`


------
https://chatgpt.com/codex/tasks/task_e_687351daebf88327a91c0a0837664256