### PR TITLE
Format mesh_generator with ruff

### DIFF
--- a/src/ogum/mesh_generator.py
+++ b/src/ogum/mesh_generator.py
@@ -64,4 +64,5 @@ def generate_mesh(
     finally:
         gmsh.finalize()
 
+
 __all__ = ["generate_mesh"]


### PR DESCRIPTION
## Summary
- apply `ruff format` to mesh generator

## Testing
- `ruff format src/ogum/mesh_generator.py`

------
https://chatgpt.com/codex/tasks/task_e_6873567ba1388327a7452ca695d0a2e8