### PR TITLE
Add API startup CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,3 +22,5 @@ RUN python3 -m pip install --no-cache-dir -e .
 # 7. Expor as portas para a aplicacao Voila e para a API.
 EXPOSE 8866
 EXPOSE 8000
+
+CMD ["bash", "-lc", "uvicorn ogum.api:app --host 0.0.0.0 --port ${PORT:-8080}"]


### PR DESCRIPTION
## Summary
- launch API from Dockerfile using `uvicorn`

## Testing
- `pytest -q` *(fails: async support and missing dependencies)*
- `apt-get update -y` *(fails: 403 Forbidden)*
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68735698fc7c8327852f00e186803d88