### PR TITLE
Use NamedTemporaryFile in mesh generator

### DIFF
--- a/src/ogum/mesh_generator.py
+++ b/src/ogum/mesh_generator.py
@@ -58,7 +58,9 @@ def generate_mesh(
         )
         gmsh.model.occ.synchronize()
         gmsh.model.mesh.generate(3)
-        msh_file = tempfile.mktemp(suffix=".msh")
+        tmp = tempfile.NamedTemporaryFile(suffix=".msh", delete=False)
+        msh_file = tmp.name
+        tmp.close()
         gmsh.write(msh_file)
         return msh_file
     finally:

--- a/tests/test_mesh_generator.py
+++ b/tests/test_mesh_generator.py
@@ -1,19 +1,26 @@
 import importlib
 import os
+import tempfile
+from unittest.mock import Mock
 
 import pytest
 
 from ogum.mesh_generator import generate_mesh
 
 
-def test_generate_mesh_runs_or_errors(tmp_path):
+def test_generate_mesh_runs_or_errors(tmp_path, monkeypatch):
     try:
         importlib.import_module("gmsh")
     except Exception:
         with pytest.raises(ModuleNotFoundError):
             generate_mesh(1.0, 2.0, 0.5, 1)
     else:
+        tmp = tempfile.NamedTemporaryFile(suffix=".msh", delete=False)
+        tmp.close()
+        mock = Mock(return_value=tmp)
+        monkeypatch.setattr(tempfile, "NamedTemporaryFile", mock)
         path = generate_mesh(0.2, 1.0, 0.1, 1)
+        assert path == tmp.name
         assert os.path.isfile(path)
         assert path.endswith(".msh")
         os.remove(path)


### PR DESCRIPTION
## Summary
- replace deprecated `tempfile.mktemp` with `NamedTemporaryFile`
- patch mesh generator test for new temp file handling

## Testing
- `pytest -q` *(fails: async tests need `pytest-asyncio`, gmsh/fenics unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6873569b522483279a7f4e82d9f11a5e