### PR TITLE
Update setup-miniconda action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Miniconda
-        uses: conda-incubator/setup-miniconda@v1
+      - name: Set up Conda
+        uses: conda-incubator/setup-miniconda@v3
         with:
           environment-file: environment.yml
           activate-environment: ogum
-          auto-activate-base: false
-          miniforge-variant: Mambaforge
+          python-version: 3.11
+          auto-update-conda: true
+          channels: conda-forge
 
       - name: Install package
         shell: bash -l {0}


### PR DESCRIPTION
## Summary
- update GitHub Actions workflow to use `setup-miniconda@v3`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68765ca728008327b11453d566d0d974