### PR TITLE
Lower python version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 description = "A suite for analyzing sintering processes."
 readme = "README.md"
 # ATUALIZADO para refletir a nova base do projeto.
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
## Summary
- relax python requirement from 3.11 to 3.10 in `pyproject.toml`

## Testing
- `pytest -q` *(fails: async plugin missing, mpi4py missing, gmsh error)*

------
https://chatgpt.com/codex/tasks/task_e_6876bce807ec8327bb3c80e70b0837e5