### PR TITLE
Fix wording in material_calibrator docstring

### DIFF
--- a/src/ogum/material_calibrator.py
+++ b/src/ogum/material_calibrator.py
@@ -69,9 +69,9 @@ class MaterialCalibrator:
 
         which satisfies the governing equation exactly for an isothermal
         constant‑*k* run and remains accurate for the slowly varying
-        temperature ramps typical of flash‑sintering tests.  This choice
-        avoids the systematic over‑estimation that arises when taking
-derivatives of noisy data.
+        temperature ramps typical of flash‑sintering tests.  
+        This choice evita a super‑estimação sistemática causada 
+        pelas derivadas de dados ruidosos.
         """
         exps = [experiments] if isinstance(experiments, pd.DataFrame) else list(experiments)
 


### PR DESCRIPTION
## Summary
- fix docstring wording in `material_calibrator.fit`

## Testing
- `pytest -k material_calibrator -q`


------
https://chatgpt.com/codex/tasks/task_e_6876bce62a1883279b2bfda8fd44a155