### PR TITLE
Add CLI entrypoint and version metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,3 +55,6 @@ pydocstyle.convention = "google"
 asyncio_mode = "auto"
 pythonpath = "src"
 testpaths = "tests"
+
+[project.scripts]
+ogum = "ogum.cli:cli"

--- a/src/ogum/__init__.py
+++ b/src/ogum/__init__.py
@@ -1,5 +1,12 @@
 """Ogum Sintering modules."""
 
+from importlib.metadata import PackageNotFoundError, version
+
+try:  # retrieving distribution version
+    __version__ = version("ogum-sintering-suite")
+except PackageNotFoundError:  # running in editable mode
+    __version__ = "0.dev0"
+
 from .core import (
     R,
     SinteringDataRecord,

--- a/src/ogum/cli.py
+++ b/src/ogum/cli.py
@@ -1,0 +1,22 @@
+"""Ogum command-line interface utilities."""
+
+import click
+from . import __version__
+
+
+@click.group()
+@click.version_option(__version__)
+def cli():
+    """Ogum command-line interface."""
+
+
+@cli.command()
+def doctors():
+    """Run environment diagnostics."""
+    from .diagnostics import run_diagnostics  # hypotético
+
+    run_diagnostics()
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
## Summary
- expose package version in `src/ogum/__init__.py`
- add `src/ogum/cli.py` with `doctors` command for diagnostics
- register `ogum` console script in `pyproject.toml`

## Testing
- `ruff check src/ogum/cli.py`
- `ruff format --check src/ogum/cli.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6876c03c231483278a80d8447d6f6db3