### PR TITLE
Fix Ruff warnings in ogum

### DIFF
--- a/src/ogum/core.py
+++ b/src/ogum/core.py
@@ -23,15 +23,20 @@ try:
 except Exception:  # pragma: no cover - optional dependency
 
     class _Dummy:
+        """Fallback widget used when ``ipywidgets`` is unavailable."""
+
         def __getattr__(self, name):
+            """Raise an error indicating the missing optional dependency."""
             raise RuntimeError("ipywidgets is required for GUI functions")
 
     widgets = _Dummy()
 
     def display(*args, **kwargs):  # type: ignore
+        """Stub ``display`` when running without IPython."""
         pass
 
     def HTML(text):  # type: ignore
+        """Return ``text`` unchanged as a minimal HTML stub."""
         return text
 
 

--- a/src/ogum/final_report.py
+++ b/src/ogum/final_report.py
@@ -27,6 +27,7 @@ class FinalReportModule:
         self._build_ui()
 
     def _build_ui(self) -> None:
+        """Create the widget layout used by the report module."""
         self.btn_generate = widgets.Button(
             description="Gerar Relatório Estatístico", button_style="info"
         )
@@ -42,6 +43,7 @@ class FinalReportModule:
         )
 
     def _on_generate_report(self, _=None) -> None:
+        """Generate the report and display the resulting HTML."""
         if self.on_busy:
             self.on_busy(True, "Gerando relatório...")
         with self.out:

--- a/src/ogum/material_calibrator.py
+++ b/src/ogum/material_calibrator.py
@@ -5,18 +5,18 @@ activation energy *Ea* and pre‑exponential factor *A* from densification
 curves (density vs. time & temperature).
 
 **Key idea** – For many sintering models we can write the densification rate
-as
+as::
 
-    dx/dt = (1 − x) · k(T) ,
+    dx/dt = (1 − x) · k(T)
 
-which integrates (for *k* constant) to
+which integrates (for *k* constant) to::
 
-    x(t) = 1 − exp(−k·t) .
+    x(t) = 1 − exp(−k·t)
 
 Even when *k* varies slowly with temperature, the *instantaneous* kinetic
-coefficient can still be estimated at each point by
+coefficient can still be estimated at each point by::
 
-    k_eff(t) =  −ln(1 − x) / t .
+    k_eff(t) = −ln(1 − x) / t
 
 Unlike finite‑difference formulas, this expression is **bias‑free** for the
 synthetic data used in the unit tests and very robust to moderate noise.

--- a/src/ogum/mesh_generator_ui.py
+++ b/src/ogum/mesh_generator_ui.py
@@ -61,6 +61,7 @@ class MeshGeneratorUI:
         self._update()
 
     def _update(self, _=None) -> None:
+        """Regenerate and plot the mesh using current widget values."""
         with self.output:
             clear_output(wait=True)
             try:


### PR DESCRIPTION
## Summary
- add fallback docstrings for optional widget stubs
- document internal methods in UI helpers
- reflow MaterialCalibrator module docstring

## Testing
- `ruff check src/ogum`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6876c0029180832786be1cc70a77dc5d