### PR TITLE
Configure CORS and add OpenAPI tags

### DIFF
--- a/src/ogum/api/__init__.py
+++ b/src/ogum/api/__init__.py
@@ -1,9 +1,23 @@
 """FastAPI application for Ogum."""
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
 from .router import router
 
 app = FastAPI(title="Ogum API")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+openapi_tags = [
+    {"name": "Master", "description": "Cálculo da curva mestra"},
+    {"name": "FEM", "description": "Simulação elementos finitos"},
+]
+app.openapi_tags = openapi_tags
 app.include_router(router)
 
 __all__ = ["app"]

--- a/src/ogum/api/router.py
+++ b/src/ogum/api/router.py
@@ -42,7 +42,7 @@ class FEMInput(BaseModel):
     A: float
 
 
-@router.post("/calc-master", response_model=MasterOutput)
+@router.post("/calc-master", response_model=MasterOutput, tags=["Master"])
 def calc_master(input: MasterInput) -> dict:
     """Calculate the master curve for a sintering experiment."""
     df = pd.DataFrame(
@@ -61,7 +61,7 @@ def calc_master(input: MasterInput) -> dict:
     }
 
 
-@router.post("/fem-sim")
+@router.post("/fem-sim", tags=["FEM"])
 def fem_sim(input: FEMInput) -> dict[str, list[float]]:
     """Run a simple FEM densification simulation."""
     mesh = create_unit_mesh(input.mesh_size)
@@ -69,7 +69,7 @@ def fem_sim(input: FEMInput) -> dict[str, list[float]]:
     return {"densities": densities.tolist()}
 
 
-@router.get("/health")
+@router.get("/health", tags=["Health"])
 def health() -> dict[str, str]:
     """Return application status."""
     return {"status": "ok"}


### PR DESCRIPTION
## Summary
- enable permissive CORS middleware in the FastAPI app
- document Master and FEM endpoints via tag metadata
- attach tags to key API routes

## Testing
- `ruff check src/ogum/api/__init__.py src/ogum/api/router.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6876c361be688327a8112d4b57202b56