### PR TITLE
Add development compose file

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ Você acessa a interface Voila em [http://localhost:8866](http://localhost:8866)
 e a API em [http://localhost:8000](http://localhost:8000) com docs em
 [http://localhost:8000/docs](http://localhost:8000/docs)
 
+Para desenvolvimento local com autoreload, use:
+```bash
+docker compose -f docker-compose.dev.yml up --build
+```
+
 ## Estrutura do código
 O diretório `src/ogum/` reúne os módulos Python gerados a partir dos notebooks em
 `notebooks/`. Esses notebooks são exportados para arquivos `.py` que dependem

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,11 @@
+version: "3.9"
+services:
+  api:
+    build: .
+    command: uvicorn ogum.api:app --reload --host 0.0.0.0 --port 8000
+    ports: ["8000:8000"]
+  voila:
+    build: .
+    command: voila notebooks/app.ipynb --port=8866 --no-browser --Voila.ip --Voila.base_url=/
+    ports: ["8866:8866"]
+    depends_on: [api]


### PR DESCRIPTION
## Summary
- add a `docker-compose.dev.yml` for local development with API reload
- document usage in the README

## Testing
- `git log -1 -p`


------
https://chatgpt.com/codex/tasks/task_e_6876c36b881883279c8c5865b1da4915