### PR TITLE
Add Sphinx docs skeleton

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,7 @@
+API Reference
+=============
+
+.. automodule:: ogum.material_calibrator
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath('../src'))
+
+project = "Ogum Sintering Suite"
+
+from ogum import __version__ as _version
+version = release = _version
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.autosummary',
+]
+
+autosummary_generate = True

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,7 @@
+Ogum Suite Documentation
+========================
+
+.. toctree::
+   :maxdepth: 2
+
+   api

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx>=7
+sphinx-autobuild>=2024.4


### PR DESCRIPTION
## Summary
- add initial Sphinx configuration under `docs/`
- include index page and API stub
- provide documentation requirements

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_6876c403131083278db52e68c78724bd