### PR TITLE
Implement CLI doctors command

### DIFF
--- a/src/ogum/cli.py
+++ b/src/ogum/cli.py
@@ -2,6 +2,7 @@
 
 import click
 from . import __version__
+from diagnostics import run_diagnostics
 
 
 @click.group()
@@ -13,8 +14,6 @@ def cli():
 @cli.command()
 def doctors():
     """Run environment diagnostics."""
-    from .diagnostics import run_diagnostics  # hypotético
-
     run_diagnostics()
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,9 @@
+from click.testing import CliRunner
+
+from ogum.cli import cli
+
+
+def test_doctors_command():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["doctors"])
+    assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- expose `diagnostics.run_diagnostics` through a new `doctors` command
- cover command with basic CLI test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6876c35aa8ec8327a29c9778d77e8cd5