### PR TITLE
Add NaN-free log theta test

### DIFF
--- a/src/ogum/processing.py
+++ b/src/ogum/processing.py
@@ -45,11 +45,14 @@ def calculate_log_theta(
 
     theta_inst = (1.0 / T_k) * np.exp(-Ea_j / (R * T_k))
     integrated = cumtrapz(
-        theta_inst, df_ensaio[time_col].to_numpy(dtype=float), initial=0
+        theta_inst,
+        df_ensaio[time_col].to_numpy(dtype=float),
+        initial=0,
     )
 
     with np.errstate(divide="ignore", invalid="ignore"):
-        log_integrated = np.log10(integrated)
+        safe_int = np.where(integrated == 0, np.finfo(float).tiny, integrated)
+        log_integrated = np.log10(safe_int)
     log_integrated[~np.isfinite(log_integrated)] = np.nan
 
     return pd.DataFrame(

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -25,3 +25,16 @@ def test_calculate_log_theta_missing_columns():
     df = pd.DataFrame({"Time_s": [0, 1], "Temperature_C": [100, 110]})
     with pytest.raises(ValueError):
         calculate_log_theta(df, 50.0)
+
+
+def test_calculate_log_theta_no_nan():
+    df = pd.DataFrame(
+        {
+            "Time_s": [0, 1, 2],
+            "Temperature_C": [100.0, 100.0, 100.0],
+            "DensidadePct": [0.0, 10.0, 20.0],
+        }
+    )
+    result = calculate_log_theta(df, 60)
+
+    assert result["logtheta"].isna().sum() == 0


### PR DESCRIPTION
## Summary
- avoid NaNs in `calculate_log_theta`
- add regression test ensuring `logtheta` column has no NaNs

## Testing
- `pytest tests/test_processing.py::test_calculate_log_theta_no_nan -q`
- `pytest -q` *(fails: async plugin missing; mpi4py/FEniCSx/gmsh not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6876c4514474832785bf44bbf3ebbc63