### PR TITLE
Add log theta and config tests

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,11 @@
+import os
+
+from ogum.config import Settings
+
+
+def test_settings_env(monkeypatch):
+    monkeypatch.setenv("GCP_PROJECT_ID", "my-proj")
+    monkeypatch.setenv("DOCKER_REPO", "docker/repo")
+    s = Settings()
+    assert s.gcp_project_id == "my-proj"
+    assert s.docker_repo == "docker/repo"

--- a/tests/test_processing_logtheta.py
+++ b/tests/test_processing_logtheta.py
@@ -1,0 +1,13 @@
+import numpy as np
+import pandas as pd
+
+from ogum.processing import calculate_log_theta
+
+
+def test_logtheta_no_nan():
+    t = np.array([0.1, 0.2, 0.3])
+    T = np.array([1000, 1010, 1020])
+    x = np.array([10, 30, 60])  # densidade %
+    df = pd.DataFrame({"Time_s": t, "Temperature_C": T, "DensidadePct": x})
+    out = calculate_log_theta(df, 60)
+    assert out["logtheta"].notna().all()


### PR DESCRIPTION
## Summary
- test calculate_log_theta output for NaNs
- test Settings environment variable loading

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6876c69a17bc83279e11148d06933993