### PR TITLE
Add bump version workflow

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,13 @@
+name: Bump version
+on:
+  workflow_dispatch:
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Bump patch
+        run: |
+          pip install bump-my-version
+          bump-my-version bump patch
+          git push --follow-tags


### PR DESCRIPTION
## Summary
- add a GitHub workflow to bump the patch version using bump-my-version

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6876c934c2bc832790e06fcfcac4c45c