### PR TITLE
Update config settings test

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,8 +4,8 @@ from ogum.config import Settings
 
 
 def test_settings_env(monkeypatch):
-    monkeypatch.setenv("GCP_PROJECT_ID", "my-proj")
-    monkeypatch.setenv("DOCKER_REPO", "docker/repo")
+    monkeypatch.setenv("GCP_PROJECT_ID", "demo-proj")
+    monkeypatch.setenv("DOCKER_REPO", "demo/repo")
     s = Settings()
-    assert s.gcp_project_id == "my-proj"
-    assert s.docker_repo == "docker/repo"
+    assert s.gcp_project_id == "demo-proj"
+    assert s.docker_repo == "demo/repo"


### PR DESCRIPTION
## Summary
- tweak config test to use demo environment values

## Testing
- `pytest -q tests/test_config.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6876c911f61c8327b4e49527d402a561