### PR TITLE
Add simple API route test

### DIFF
--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+from ogum.api import app
+
+client = TestClient(app)
+
+
+def test_health_route():
+    r = client.get("/health")
+    assert r.status_code == 200
+    assert r.json()["status"] == "ok"


### PR DESCRIPTION
## Summary
- add a simple health route test using FastAPI TestClient

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx', 'pandas', 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6876c91b96788327821cb938c28c5634