### PR TITLE
Add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+lint:
+	ruff check src
+
+format:
+	ruff format src
+
+test:
+	pytest -q
+
+docs:
+	sphinx-build -b html docs docs/_build/html
+
+diag:
+	python scripts/build_diagnostics.py


### PR DESCRIPTION
## Summary
- add a basic Makefile with lint, format, test, docs and diag targets

## Testing
- `ruff check src` *(fails: D100 Missing docstring)*
- `pytest -q` *(fails: missing modules such as numpy and pandas)*
- `sphinx-build -b html docs docs/_build/html` *(fails: command not found)*
- `python scripts/build_diagnostics.py` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876c924d1b883279860ee5c0e876186