### PR TITLE
Update dev Docker Compose

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,6 +6,6 @@ services:
     ports: ["8000:8000"]
   voila:
     build: .
-    command: voila notebooks/app.ipynb --port=8866 --no-browser --Voila.ip --Voila.base_url=/
+    command: voila notebooks/app.ipynb --port=8866 --no-browser --Voila.ip=0.0.0.0
     ports: ["8866:8866"]
     depends_on: [api]


### PR DESCRIPTION
## Summary
- adjust the command for the `voila` service in `docker-compose.dev.yml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6876c92c431483278c75965b702cabc3