### PR TITLE
Add docs build step to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,13 @@ jobs:
       - name: Authenticate Docker to Artifact Registry
         run: gcloud auth configure-docker southamerica-east1-docker.pkg.dev
 
-      # 10. Build e push da imagem -------------------------------------------------
+      # 10. Build docs ---------------------------------------------------------
+      - name: Build docs
+        shell: bash -l {0}
+        run: sphinx-build -b html docs docs/_build/html
+
+
+      # 11. Build e push da imagem -------------------------------------------------
       - name: Build & Push Docker image
         run: |
           docker build -t southamerica-east1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/ogum/ogumsoftware:latest .


### PR DESCRIPTION
## Summary
- automate docs generation in CI before Docker build

## Testing
- `ruff check --exit-zero src`
- `ruff format --check src || true`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `sphinx-build -b html docs docs/_build/html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876c94702548327b8cb5b9e74910423