### PR TITLE
Add GitHub Pages workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,19 @@
+name: Docs Pages
+on:
+  push:
+    branches: [main]
+    paths: ["docs/**", "src/**"]
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build
+        run: |
+          pip install -r docs/requirements.txt
+          sphinx-build -b html docs docs/_build/html
+      - uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/_build/html
+


### PR DESCRIPTION
## Summary
- add workflow to deploy docs to GitHub Pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876c94d7f488327ae612789175a8379