### PR TITLE
Add workflow to publish package to TestPyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,18 @@
+name: Publish TestPyPI
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pypa/cibuildwheel@v2
+      - uses: pypa/gh-action-pypi-publish@v1
+        with:
+          repository_url: https://test.pypi.org/legacy/
+          password: ${{ secrets.TEST_PYPI_TOKEN }}
+


### PR DESCRIPTION
## Summary
- add publish workflow for TestPyPI using cibuildwheel

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6876c9c444d08327b28a7b76701469a8