### PR TITLE
Fix diagnostics wrapper and migrate to pydantic-settings

### DIFF
--- a/diagnostics.py
+++ b/diagnostics.py
@@ -116,5 +116,12 @@ def main() -> None:
     print("✅ Ambiente estável" if ok else "❌ Problemas detectados")
     sys.exit(0 if ok else 1)
 
+# ---------------------------------------------------------------------------
+# Public wrapper requerido por CLI e pelos testes
+# ---------------------------------------------------------------------------
+def run_diagnostics() -> None:
+    """Wrapper estável – simplesmente chama :pyfunc:`main`."""
+    main()
+
 if __name__ == "__main__":
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ gmsh
 fastapi
 uvicorn[standard]
 pydantic
+pydantic-settings>=2.1
 httpx
 
 # Web UI

--- a/src/ogum/cli.py
+++ b/src/ogum/cli.py
@@ -2,7 +2,7 @@
 
 import click
 from . import __version__
-from diagnostics import run_diagnostics
+import diagnostics
 
 
 @click.group()
@@ -14,7 +14,7 @@ def cli():
 @cli.command()
 def doctors():
     """Run environment diagnostics."""
-    run_diagnostics()
+    diagnostics.run_diagnostics()
 
 
 if __name__ == "__main__":

--- a/src/ogum/config.py
+++ b/src/ogum/config.py
@@ -1,4 +1,5 @@
-from pydantic import BaseSettings, Field
+from pydantic_settings import BaseSettings
+from pydantic import Field
 
 
 class Settings(BaseSettings):


### PR DESCRIPTION
## Summary
- expose `run_diagnostics` wrapper in `diagnostics.py`
- import diagnostics module in CLI and use the wrapper
- update configuration to use `pydantic_settings.BaseSettings`
- add new dependency in requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_6876d4cc69d4832799d098b1fcbd684d