### PR TITLE
Implement master curve builder

### DIFF
--- a/src/ogum/__init__.py
+++ b/src/ogum/__init__.py
@@ -23,6 +23,7 @@ from .core import (
 from .utils import normalize_columns, orlandini_araujo_filter, savgol_filter
 from .plotting import plot_sintering_curves
 from .processing import calculate_log_theta
+from .master_curve import build_master_curve
 from .material_calibrator import MaterialCalibrator
 from .stats import bootstrap_ea, shapiro_residuals, generate_report
 from .final_report import FinalReportModule
@@ -46,6 +47,7 @@ __all__ = [
     "orlandini_araujo_filter",
     "savgol_filter",
     "calculate_log_theta",
+    "build_master_curve",
     "MaterialCalibrator",
     "plot_sintering_curves",
     "bootstrap_ea",

--- a/src/ogum/master_curve.py
+++ b/src/ogum/master_curve.py
@@ -1,0 +1,69 @@
+"""Master curve construction utilities."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import numpy as np
+import pandas as pd
+
+from .core import R
+
+
+def _estimate_activation_energy(time: np.ndarray, temp_c: np.ndarray, dens: np.ndarray) -> float:
+    """Return activation energy in kJ/mol estimated from densification data."""
+    x = dens.copy().astype(float)
+    if x.max() > 1.0:
+        x /= 100.0
+    mask = (time > 0) & (0 < x) & (x < 1)
+    if mask.sum() < 2:
+        raise ValueError("Insufficient data for activation energy fit")
+    k_eff = -np.log(1.0 - x[mask]) / time[mask]
+    inv_T = 1.0 / (temp_c[mask].astype(float) + 273.15)
+    slope, _ = np.polyfit(inv_T, np.log(k_eff), 1)
+    Ea_j = -slope * R
+    return float(Ea_j / 1000.0)
+
+
+def build_master_curve(df: pd.DataFrame, method: Literal["arrhenius"] = "arrhenius") -> pd.DataFrame:
+    """Return Arrhenius master curve for densification data.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Input data with ``time``, ``temperature`` and ``density`` columns.
+    method : {{'arrhenius'}}, default 'arrhenius'
+        Superposition method to apply.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Columns ``master_time``, ``master_density`` and ``activation_energy``.
+    """
+    if method != "arrhenius":
+        raise ValueError("Only 'arrhenius' method is supported")
+    required = {"time", "temperature", "density"}
+    if not required <= set(df.columns):
+        raise ValueError("Input DataFrame must contain 'time', 'temperature' and 'density'")
+
+    t = df["time"].to_numpy(float)
+    T_c = df["temperature"].to_numpy(float)
+    dens = df["density"].to_numpy(float)
+
+    Ea_kJ = _estimate_activation_energy(t, T_c, dens)
+    T_ref = np.mean(T_c) + 273.15
+    T_k = T_c + 273.15
+    a_T = np.exp((Ea_kJ * 1000.0 / R) * (1.0 / T_k - 1.0 / T_ref))
+    master_time = t * a_T
+
+    result = pd.DataFrame(
+        {
+            "master_time": master_time,
+            "master_density": dens,
+            "activation_energy": np.full_like(master_time, Ea_kJ, dtype=float),
+        }
+    )
+    return result
+
+
+__all__ = ["build_master_curve"]

--- a/tests/test_master_curve.py
+++ b/tests/test_master_curve.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pandas as pd
+
+from ogum.master_curve import build_master_curve
+from ogum.material_calibrator import MaterialCalibrator
+
+
+def _synthetic() -> pd.DataFrame:
+    t = np.linspace(0, 2, 20)
+    df = MaterialCalibrator.simulate_synthetic(60.0, 2.0, t)
+    return df.rename(
+        columns={"Time_s": "time", "Temperature_C": "temperature", "DensidadePct": "density"}
+    )
+
+
+def test_build_master_curve_structure():
+    df = _synthetic()
+    result = build_master_curve(df)
+    assert list(result.columns) == ["master_time", "master_density", "activation_energy"]
+    assert len(result) == len(df)
+
+
+def test_build_master_curve_activation_energy():
+    df = _synthetic()
+    result = build_master_curve(df)
+    ea = result["activation_energy"].iloc[0]
+    assert np.isclose(ea, 60.0, rtol=0.3)
+


### PR DESCRIPTION
## Summary
- add master curve construction in new module
- expose `build_master_curve` via package init
- test synthetic master curve behaviour

## Testing
- `ruff check src/ogum/master_curve.py tests/test_master_curve.py` *(fails: D416 Returns section requires colon)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68793360d5088327acca1a7c77dcb58d