### PR TITLE
Implement MaterialCalibrator with predictive model

### DIFF
--- a/src/ogum/material_calibrator.py
+++ b/src/ogum/material_calibrator.py
@@ -1,137 +1,105 @@
-"""Tools for calibrating material kinetics from flash‑sintering experiments.
-
-This module provides the ``MaterialCalibrator`` class, which extracts the
-activation energy *Ea* and pre‑exponential factor *A* from densification
-curves (density vs. time & temperature).
-
-**Key idea** – For many sintering models we can write the densification rate
-as::
-
-    dx/dt = (1 − x) · k(T)
-
-which integrates (for *k* constant) to::
-
-    x(t) = 1 − exp(−k·t)
-
-Even when *k* varies slowly with temperature, the *instantaneous* kinetic
-coefficient can still be estimated at each point by::
-
-    k_eff(t) = −ln(1 − x) / t
-
-Unlike finite‑difference formulas, this expression is **bias‑free** for the
-synthetic data used in the unit tests and very robust to moderate noise.
-"""
+"""Utilities for calibrating Arrhenius parameters from sintering data."""
 
 from __future__ import annotations
 
-from typing import List, Tuple, Union
+from typing import Dict
 
 import numpy as np
 import pandas as pd
+from scipy.optimize import curve_fit
 
-from .core import R  # universal gas constant (J mol⁻¹ K⁻¹)
-from .processing import calculate_log_theta
+from .core import R
 
-# ------------------------------------------------------------------------------------------------------------------
 
 class MaterialCalibrator:
-    """Calibrate activation energy (Ea, kJ mol⁻¹) and pre‑exponential factor (A, s⁻¹)."""
+    """Fit and predict densification using an Arrhenius model."""
 
-    # --------------------------------------------------------------------------------------------------------------
-    # Construction & helpers
-    # --------------------------------------------------------------------------------------------------------------
+    def __init__(self, Ea: float | None = None, A: float | None = None) -> None:
+        """Create a calibrator instance.
 
-    def __init__(self, experiments: Union[pd.DataFrame, List[pd.DataFrame]]) -> None:
-        """Store one or more experimental DataFrames.
-
-        Each DataFrame must contain the columns:
-            * ``Time_s``        – time in seconds
-            * ``Temperature_C`` – temperature in °C
-            * ``DensidadePct``  – relative density in *percent* (0–100)
+        Parameters
+        ----------
+        Ea : float, optional
+            Activation energy in kJ/mol.
+        A : float, optional
+            Pre-exponential factor in s⁻¹.
         """
-        self.experiments: List[pd.DataFrame]
-        if isinstance(experiments, pd.DataFrame):
-            self.experiments = [experiments]
-        else:
-            self.experiments = list(experiments)
-
-    # --------------------------------------------------------------------------------------------------------------
-    # Core calibration routine
-    # --------------------------------------------------------------------------------------------------------------
+        self.Ea = Ea
+        self.A = A
 
     @staticmethod
-    def fit(experiments: Union[pd.DataFrame, List[pd.DataFrame]]) -> Tuple[float, float]:
-        """Return ``(Ea_kJ, A)`` fitted from the provided experiments.
+    def _arrhenius_rate(T_k: np.ndarray, Ea: float, A: float) -> np.ndarray:
+        Ea_j = Ea * 1000.0
+        return A * np.exp(-Ea_j / (R * T_k))
 
-        The algorithm uses the point‑wise estimator
+    @staticmethod
+    def _densification(t: np.ndarray, T_c: np.ndarray, Ea: float, A: float) -> np.ndarray:
+        T_k = T_c + 273.15
+        rates = MaterialCalibrator._arrhenius_rate(T_k, Ea, A)
+        x = np.zeros_like(t, dtype=float)
+        for i in range(1, len(t)):
+            dt = t[i] - t[i - 1]
+            x[i] = x[i - 1] + dt * (1.0 - x[i - 1]) * rates[i - 1]
+        return x
 
-            ``k_eff = −ln(1 − x) / t``
+    def fit(self, df: pd.DataFrame) -> Dict[str, float]:
+        """Estimate ``Ea`` and ``A`` from experimental data.
 
-        which satisfies the governing equation exactly for an isothermal
-        constant‑*k* run and remains accurate for the slowly varying
-        temperature ramps typical of flash‑sintering tests.  
-        This choice evita a super‑estimação sistemática causada 
-        pelas derivadas de dados ruidosos.
+        Parameters
+        ----------
+        df : pandas.DataFrame
+            DataFrame with ``Time_s``, ``Temperature_C`` and ``DensidadePct``.
+
+        Returns:
+        -------
+        dict
+            Dictionary with keys ``'Ea'`` and ``'A'``.
         """
-        exps = [experiments] if isinstance(experiments, pd.DataFrame) else list(experiments)
+        t = df["Time_s"].to_numpy(dtype=float)
+        T = df["Temperature_C"].to_numpy(dtype=float)
+        y = df["DensidadePct"].to_numpy(dtype=float) / 100.0
 
-        T_pool: List[np.ndarray] = []      # Kelvin
-        ln_k_pool: List[np.ndarray] = []   # ln(s⁻¹)
+        def model(arr: tuple[np.ndarray, np.ndarray], Ea: float, A: float) -> np.ndarray:
+            times, temps = arr
+            return MaterialCalibrator._densification(times, temps, Ea, A)
 
-        for df in exps:
-            t = df["Time_s"].to_numpy(float)
-            T = df["Temperature_C"].to_numpy(float) + 273.15  # °C → K
-            x = df["DensidadePct"].to_numpy(float) / 100.0    # % → fraction
+        p0 = [self.Ea if self.Ea is not None else 50.0, self.A if self.A is not None else 1.0]
+        popt, _ = curve_fit(model, (t, T), y, p0=p0, bounds=(0.0, np.inf))
+        self.Ea, self.A = float(popt[0]), float(popt[1])
+        return {"Ea": self.Ea, "A": self.A}
 
-            # Exclude the first point (t = 0) to avoid division by zero
-            mask = (t > 0.0) & (0.0 < x) & (x < 1.0)
-            if not mask.any():
-                continue
+    def predict(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Predict densification curves using fitted parameters.
 
-            k_eff = -np.log(1.0 - x[mask]) / t[mask]
-            valid = (k_eff > 0) & np.isfinite(k_eff)
-            if valid.any():
-                T_pool.append(T[mask][valid])
-                ln_k_pool.append(np.log(k_eff[valid]))
+        Parameters
+        ----------
+        df : pandas.DataFrame
+            Must contain ``Time_s`` and ``Temperature_C`` columns.
 
-        if not T_pool:
-            raise ValueError("No valid data for fitting – check input DataFrames")
-
-        X = 1.0 / np.concatenate(T_pool)   # 1/T  (K⁻¹)
-        Y = np.concatenate(ln_k_pool)      # ln(k)
-
-        slope, intercept = np.polyfit(X, Y, 1)
-
-        Ea_kJ = (-slope * R) / 1000.0      # convert J → kJ
-        A = float(np.exp(intercept))
-        return float(Ea_kJ), A
-
-    # --------------------------------------------------------------------------------------------------------------
-    # Synthetic data generator ------------------------------------------------------------------------------------
-    # --------------------------------------------------------------------------------------------------------------
+        Returns:
+        -------
+        pandas.DataFrame
+            Copy of ``df`` with ``predicted_density`` column in percent.
+        """
+        if self.Ea is None or self.A is None:
+            raise ValueError("Model parameters not fitted")
+        t = df["Time_s"].to_numpy(dtype=float)
+        T = df["Temperature_C"].to_numpy(dtype=float)
+        dens = MaterialCalibrator._densification(t, T, self.Ea, self.A) * 100.0
+        result = df.copy()
+        result["predicted_density"] = dens
+        return result
 
     @staticmethod
     def simulate_synthetic(ea_kJ: float, A: float, time_array: np.ndarray) -> pd.DataFrame:
-        """Generate a synthetic flash‑sintering run for unit testing."""
-        T_c = np.linspace(1000.0, 1050.0, num=len(time_array))
-        T_k = T_c + 273.15
-        k = A * np.exp(-(ea_kJ * 1000.0) / (R * T_k))
-        dens = 1.0 - np.exp(-k * time_array)
+        """Generate synthetic densification data for testing."""
+        T_c = np.full_like(time_array, 1000.0)
+        dens = MaterialCalibrator._densification(time_array, T_c, ea_kJ, A)
         return pd.DataFrame({
             "Time_s": time_array,
             "Temperature_C": T_c,
             "DensidadePct": dens * 100.0,
         })
-
-    # --------------------------------------------------------------------------------------------------------------
-    # Master curve transformation ---------------------------------------------------------------------------------
-    # --------------------------------------------------------------------------------------------------------------
-
-    def curve_master_analysis(self) -> pd.DataFrame:
-        """Return *log‑theta* master curve for the stored experiments."""
-        ea_kJ, _ = self.fit(self.experiments)
-        frames = [calculate_log_theta(df, ea_kJ) for df in self.experiments]
-        return pd.concat(frames, ignore_index=True)
 
 
 __all__ = ["MaterialCalibrator"]

--- a/src/ogum/stats.py
+++ b/src/ogum/stats.py
@@ -43,8 +43,10 @@ def bootstrap_ea(
     for i in range(n_bootstrap):
         idx = rng.integers(0, n, n)
         sample = [experiments[j] for j in idx]
-        ea, _ = MaterialCalibrator.fit(sample)
-        eas[i] = ea
+        combined = pd.concat(sample, ignore_index=True)
+        calib = MaterialCalibrator()
+        params = calib.fit(combined)
+        eas[i] = params["Ea"]
 
     ci_low, ci_high = np.percentile(eas, [2.5, 97.5])
     return float(ci_low), float(ci_high)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -10,7 +10,7 @@ def test_bootstrap_ea_contains_true():
     t = np.linspace(0, 5, 20)
     ea_true = 60.0
     a_true = 2.0
-    calib = MaterialCalibrator(pd.DataFrame())
+    calib = MaterialCalibrator()
     experiments = []
     for _ in range(3):
         df = calib.simulate_synthetic(ea_true, a_true, t)


### PR DESCRIPTION
## Summary
- rewrite `MaterialCalibrator` with `fit` and `predict`
- adjust statistics utilities for new API
- add synthetic calibration tests
- update statistical tests

## Testing
- `ruff check src/ogum/material_calibrator.py src/ogum/stats.py tests/test_material_calibrator.py tests/test_stats.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6879349e41dc832789335a3b88451486