### PR TITLE
Add API endpoints for sintering services

### DIFF
--- a/src/ogum/api/__init__.py
+++ b/src/ogum/api/__init__.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from .router import router
+from .routes import router as services_router
 
 app = FastAPI(title="Ogum API")
 app.add_middleware(
@@ -19,5 +20,6 @@ openapi_tags = [
 ]
 app.openapi_tags = openapi_tags
 app.include_router(router)
+app.include_router(services_router)
 
 __all__ = ["app"]

--- a/src/ogum/api/routes.py
+++ b/src/ogum/api/routes.py
@@ -1,0 +1,101 @@
+"""Additional FastAPI routes exposing scientific utilities."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+import pandas as pd
+
+from ogum.data_refinement import DataRefinement
+from ogum.master_curve import build_master_curve
+from ogum.material_calibrator import MaterialCalibrator
+
+from .schemas import (
+    RefineRequest,
+    RefineResponse,
+    MasterCurveRequest,
+    MasterCurveResponse,
+    CalibrateRequest,
+    CalibrateResponse,
+    SinteringRecord,
+)
+
+router = APIRouter()
+
+
+@router.post("/refine", response_model=RefineResponse, tags=["Science"])
+def refine(data: RefineRequest) -> RefineResponse:
+    """Filter sintering data using :class:`DataRefinement`.
+
+    Parameters
+    ----------
+    data : RefineRequest
+        Records to be processed.
+
+    Returns
+    -------
+    RefineResponse
+        Filtered records.
+    """
+    df = pd.DataFrame([r.dict() for r in data.records])
+    refined = DataRefinement(df).df_refined
+    records = [
+        SinteringRecord(**row)
+        for row in refined.to_dict(orient="records")
+    ]
+    return RefineResponse(records=records)
+
+
+@router.post(
+    "/master-curve",
+    response_model=MasterCurveResponse,
+    tags=["Science"],
+)
+def master_curve(data: MasterCurveRequest) -> MasterCurveResponse:
+    """Build the Arrhenius master curve from sintering records.
+
+    Parameters
+    ----------
+    data : MasterCurveRequest
+        Input sintering data.
+
+    Returns
+    -------
+    MasterCurveResponse
+        Master curve arrays and activation energy.
+    """
+    df = pd.DataFrame([r.dict() for r in data.records])
+    curve = build_master_curve(df)
+    return MasterCurveResponse(
+        master_time=curve["master_time"].tolist(),
+        master_density=curve["master_density"].tolist(),
+        activation_energy=float(curve["activation_energy"].iloc[0]),
+    )
+
+
+@router.post("/calibrate", response_model=CalibrateResponse, tags=["Science"])
+def calibrate(data: CalibrateRequest) -> CalibrateResponse:
+    """Calibrate material parameters from sintering records.
+
+    Parameters
+    ----------
+    data : CalibrateRequest
+        Experimental data records.
+
+    Returns
+    -------
+    CalibrateResponse
+        Fitted activation energy and pre-exponential factor.
+    """
+    df = pd.DataFrame([r.dict() for r in data.records])
+    df_exp = df.rename(
+        columns={
+            "time": "Time_s",
+            "temperature": "Temperature_C",
+            "density": "DensidadePct",
+        }
+    )
+    ea, a_param = MaterialCalibrator.fit(df_exp)
+    return CalibrateResponse(Ea=ea, A=a_param)
+
+
+__all__ = ["router"]

--- a/src/ogum/api/schemas.py
+++ b/src/ogum/api/schemas.py
@@ -1,0 +1,105 @@
+"""Pydantic models for Ogum API."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class SinteringRecord(BaseModel):
+    """Single point in a sintering experiment."""
+
+    time: float
+    temperature: float
+    density: float
+
+
+class RefineRequest(BaseModel):
+    """Payload for the ``/refine`` endpoint.
+
+    Parameters
+    ----------
+    records : list[SinteringRecord]
+        Sintering data records to be filtered.
+    """
+
+    records: list[SinteringRecord]
+
+
+class RefineResponse(BaseModel):
+    """Response from the ``/refine`` endpoint.
+
+    Parameters
+    ----------
+    records : list[SinteringRecord]
+        Filtered sintering data.
+    """
+
+    records: list[SinteringRecord]
+
+
+class MasterCurveRequest(BaseModel):
+    """Input for ``/master-curve``.
+
+    Parameters
+    ----------
+    records : list[SinteringRecord]
+        Sintering data records.
+    """
+
+    records: list[SinteringRecord]
+
+
+class MasterCurveResponse(BaseModel):
+    """Master curve result.
+
+    Parameters
+    ----------
+    master_time : list[float]
+        Time values shifted to the reference temperature.
+    master_density : list[float]
+        Densities associated with ``master_time``.
+    activation_energy : float
+        Activation energy in kJ/mol used for the shift.
+    """
+
+    master_time: list[float]
+    master_density: list[float]
+    activation_energy: float
+
+
+class CalibrateRequest(BaseModel):
+    """Input for ``/calibrate``.
+
+    Parameters
+    ----------
+    records : list[SinteringRecord]
+        Sintering experiment records.
+    """
+
+    records: list[SinteringRecord]
+
+
+class CalibrateResponse(BaseModel):
+    """Calibration parameters.
+
+    Parameters
+    ----------
+    Ea : float
+        Activation energy in kJ/mol.
+    A : float
+        Pre-exponential factor in s⁻¹.
+    """
+
+    Ea: float
+    A: float
+
+
+__all__ = [
+    "SinteringRecord",
+    "RefineRequest",
+    "RefineResponse",
+    "MasterCurveRequest",
+    "MasterCurveResponse",
+    "CalibrateRequest",
+    "CalibrateResponse",
+]

--- a/tests/api/test_routes.py
+++ b/tests/api/test_routes.py
@@ -1,0 +1,76 @@
+import numpy as np
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+from ogum.api import app
+from ogum.material_calibrator import MaterialCalibrator
+
+
+def _records() -> list[dict[str, float]]:
+    t = np.linspace(0, 2, 5)
+    df = MaterialCalibrator.simulate_synthetic(60.0, 2.0, t)
+    df = df.rename(columns={"Time_s": "time", "Temperature_C": "temperature", "DensidadePct": "density"})
+    return df.to_dict(orient="records")
+
+
+@pytest.mark.asyncio
+async def test_refine_valid():
+    transport = ASGITransport(app=app)
+    data = _records()
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/refine", json={"records": data})
+    assert resp.status_code == 200
+    out = resp.json()
+    assert len(out["records"]) == len(data)
+
+
+@pytest.mark.asyncio
+async def test_refine_invalid():
+    transport = ASGITransport(app=app)
+    data = [{"time": 0.0, "temperature": 1000.0}]  # missing density
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/refine", json={"records": data})
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_master_curve_valid():
+    transport = ASGITransport(app=app)
+    data = _records()
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/master-curve", json={"records": data})
+    assert resp.status_code == 200
+    out = resp.json()
+    assert set(out) == {"master_time", "master_density", "activation_energy"}
+    assert len(out["master_time"]) == len(data)
+
+
+@pytest.mark.asyncio
+async def test_master_curve_invalid():
+    transport = ASGITransport(app=app)
+    data = [{"time": 0.0, "density": 10.0, "temperature": 1000.0}, {"time": 1.0, "density": 15.0}]  # second record missing temperature
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/master-curve", json={"records": data})
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_calibrate_valid():
+    transport = ASGITransport(app=app)
+    data = _records()
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/calibrate", json={"records": data})
+    assert resp.status_code == 200
+    out = resp.json()
+    assert {"Ea", "A"} == set(out)
+    assert out["Ea"] == pytest.approx(60.0, rel=0.3)
+    assert out["A"] == pytest.approx(2.0, rel=0.3)
+
+
+@pytest.mark.asyncio
+async def test_calibrate_invalid():
+    transport = ASGITransport(app=app)
+    data = [{"time": 0.0, "temperature": 1000.0, "density": 10.0}, {"temperature": 1000.0, "density": 20.0}]  # missing time
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/calibrate", json={"records": data})
+    assert resp.status_code == 422


### PR DESCRIPTION
## Summary
- expose scientific utilities via new `/refine`, `/master-curve` and `/calibrate` endpoints
- define pydantic request/response schemas for the new services
- register routes with the FastAPI app
- provide async integration tests for each endpoint

## Testing
- `ruff check src` *(fails: D416 warnings)*
- `pytest -q` *(fails to collect: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6879357436fc8327beed85feb7e72e8b